### PR TITLE
低コストLLM向けに会社snapshotを安定化する

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -193,6 +193,7 @@ export async function runCli() {
   });
 
   // Incremental history tracking
+  let lastRenderedItemId = '';
   let lastRenderedEventCount = 0;
   let lastRenderedStatus = '';
   let lastRenderedAnswer = false;
@@ -207,9 +208,14 @@ export async function runCli() {
       const lastItem = history[history.length - 1];
       if (lastItem) {
         // New query started
-        if (lastItem.events.length === 0 && lastRenderedEventCount === 0 && !lastRenderedAnswer) {
+        if (lastItem.id !== lastRenderedItemId) {
           chatLog.addQuery(lastItem.query);
           chatLog.resetToolGrouping();
+          lastRenderedItemId = lastItem.id;
+          lastRenderedEventCount = 0;
+          lastRenderedStatus = '';
+          lastRenderedAnswer = false;
+          finalizedToolIds.clear();
         }
 
         // Render new events only
@@ -423,6 +429,7 @@ export async function runCli() {
 
     await inputHistory.saveMessage(query);
     inputHistory.resetNavigation();
+    lastRenderedItemId = '';
     lastRenderedEventCount = 0;
     lastRenderedStatus = '';
     lastRenderedAnswer = false;

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -10,6 +10,8 @@ export interface ProviderDef {
   displayName: string;
   /** Model name prefix used for routing (e.g., 'claude-'). Empty string for default (OpenAI). */
   modelPrefix: string;
+  /** Additional model prefixes for providers that expose multiple model families. */
+  modelPrefixes?: string[];
   /** Environment variable name for API key. Omit for local providers (e.g., Ollama). */
   apiKeyEnvVar?: string;
   /** Fast model variant for lightweight tasks like summarization. */
@@ -39,6 +41,7 @@ export const PROVIDERS: ProviderDef[] = [
     id: 'google',
     displayName: 'Google',
     modelPrefix: 'gemini-',
+    modelPrefixes: ['gemini-', 'gemma-'],
     apiKeyEnvVar: 'GOOGLE_API_KEY',
     fastModel: 'gemini-3-flash-preview',
     contextWindow: 1_000_000,
@@ -91,7 +94,10 @@ const defaultProvider = PROVIDERS.find((p) => p.id === 'openai')!;
  */
 export function resolveProvider(modelName: string): ProviderDef {
   return (
-    PROVIDERS.find((p) => p.modelPrefix && modelName.startsWith(p.modelPrefix)) ??
+    PROVIDERS.find((p) => {
+      const prefixes = p.modelPrefixes ?? (p.modelPrefix ? [p.modelPrefix] : []);
+      return prefixes.some((prefix) => modelName.startsWith(prefix));
+    }) ??
     defaultProvider
   );
 }

--- a/src/tools/finance/get-financials.test.ts
+++ b/src/tools/finance/get-financials.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  compactFinanceResult,
+  getDeterministicCompanySnapshotRoute,
+} from './get-financials.js';
+
+describe('compactFinanceResult', () => {
+  test('keeps company snapshots compact and adds packet diagnostics', () => {
+    const result = compactFinanceResult('get_company_info', {
+      name: 'Toyota Motor Corporation',
+      sec_code: '7203',
+      industry: '輸送用機器',
+      giant_payload: [{ unused: true }],
+      latest_financials: {
+        fiscal_year: 2025,
+        revenue: 48000000000000,
+        operating_income: 4000000000000,
+        per: 7.3,
+        unused_field: 'drop me',
+      },
+    }) as Record<string, unknown>;
+    const keyMetrics = result.key_metrics as Record<string, Record<string, unknown>>;
+
+    expect(result.name).toBe('Toyota Motor Corporation');
+    expect(result.sec_code).toBe('7203');
+    expect(result.giant_payload).toBeUndefined();
+    expect(result.latest_financials).toEqual({
+      fiscal_year: 2025,
+      revenue: 48000000000000,
+      operating_income: 4000000000000,
+      per: 7.3,
+    });
+    expect(keyMetrics.per).toEqual({
+      label: 'PER (Price-to-Earnings Ratio) / 株価収益率',
+      value: 7.3,
+      unit: 'x',
+      status: 'available',
+      sourceField: 'latest_financials.per',
+    });
+    expect(keyMetrics.pbr).toEqual({
+      label: 'PBR (Price-to-Book Ratio) / 株価純資産倍率',
+      value: null,
+      unit: 'x',
+      status: 'unavailable',
+      sourceField: 'latest_financials.pbr',
+      note: 'PBR is not available in this company snapshot source. Do not infer PBR from PER.',
+    });
+    expect(keyMetrics.pbr.value).not.toBe(7.3);
+    expect(result._packet).toEqual({
+      packetType: 'company_snapshot',
+      sourceTool: 'get_company_info',
+      compacted: true,
+      selectedFieldCount: 5,
+    });
+  });
+
+  test('falls back to original data when compact extraction is unusable', () => {
+    const original = {
+      unexpected_payload: {
+        still_needed: true,
+      },
+    };
+
+    const result = compactFinanceResult('get_company_info', original) as Record<string, unknown>;
+
+    expect(result.unexpected_payload).toEqual(original.unexpected_payload);
+    expect(result).not.toEqual({});
+    expect(result._packet).toEqual({
+      packetType: 'company_snapshot',
+      sourceTool: 'get_company_info',
+      compacted: false,
+      selectedFieldCount: 0,
+      fallbackReason: 'compact_packet_unusable',
+    });
+  });
+});
+
+describe('getDeterministicCompanySnapshotRoute', () => {
+  test('routes simple company overview and latest financials queries directly to get_company_info', () => {
+    const route = getDeterministicCompanySnapshotRoute('トヨタの会社概要と直近の主要財務を簡単に確認して');
+
+    expect(route).toEqual({
+      tool: 'get_company_info',
+      args: { ticker: '7203' },
+    });
+  });
+
+  test('passes through unambiguous securities codes for snapshot queries', () => {
+    const route = getDeterministicCompanySnapshotRoute('7203の会社概要と直近の主要財務を簡単に確認して');
+
+    expect(route).toEqual({
+      tool: 'get_company_info',
+      args: { ticker: '7203' },
+    });
+  });
+
+  test('passes through unambiguous EDINET codes for snapshot queries', () => {
+    const route = getDeterministicCompanySnapshotRoute('E02144の会社概要と直近の主要財務を簡単に確認して');
+
+    expect(route).toEqual({
+      tool: 'get_company_info',
+      args: { ticker: 'E02144' },
+    });
+  });
+
+  test('does not treat years as securities codes before whitelisted aliases', () => {
+    const route = getDeterministicCompanySnapshotRoute('トヨタの2025年の会社概要と直近の主要財務を確認して');
+
+    expect(route).toEqual({
+      tool: 'get_company_info',
+      args: { ticker: '7203' },
+    });
+  });
+
+  test('falls back to the LLM router for non-whitelisted bare company names', () => {
+    expect(getDeterministicCompanySnapshotRoute('ソニーの会社概要と直近の主要財務を確認して')).toBeNull();
+    expect(getDeterministicCompanySnapshotRoute('三菱の会社概要と直近の主要財務を確認して')).toBeNull();
+  });
+
+  test('falls back for mixed identifiers or numeric amounts', () => {
+    expect(getDeterministicCompanySnapshotRoute('7203とホンダの会社概要と直近財務を確認して')).toBeNull();
+    expect(getDeterministicCompanySnapshotRoute('E02144と7267の会社概要と直近財務を確認して')).toBeNull();
+    expect(getDeterministicCompanySnapshotRoute('E02144とホンダの会社概要と直近財務を確認して')).toBeNull();
+    expect(getDeterministicCompanySnapshotRoute('売上高1000億円の会社概要と直近財務を確認して')).toBeNull();
+  });
+
+  test('falls back for multi-intent snapshot plus analysis or detailed ratio asks', () => {
+    expect(getDeterministicCompanySnapshotRoute('トヨタの会社概要と直近財務と財務健全性スコアを確認して')).toBeNull();
+    expect(getDeterministicCompanySnapshotRoute('トヨタの会社概要と直近財務、財務分析もして')).toBeNull();
+    expect(getDeterministicCompanySnapshotRoute('トヨタの会社概要と直近財務、ROICとROEを詳しく')).toBeNull();
+  });
+
+  test('does not route comparisons, filings, earnings, screening, or trend queries', () => {
+    expect(getDeterministicCompanySnapshotRoute('トヨタとホンダの会社概要と直近財務を比較して')).toBeNull();
+    expect(getDeterministicCompanySnapshotRoute('トヨタとホンダの会社概要と直近財務を確認して')).toBeNull();
+    expect(getDeterministicCompanySnapshotRoute('7203と7267の会社概要と直近財務を確認して')).toBeNull();
+    expect(getDeterministicCompanySnapshotRoute('トヨタの有価証券報告書から会社概要と直近財務を確認して')).toBeNull();
+    expect(getDeterministicCompanySnapshotRoute('トヨタの会社概要と直近の決算短信を確認して')).toBeNull();
+    expect(getDeterministicCompanySnapshotRoute('会社概要と直近財務が良い企業をスクリーニングして')).toBeNull();
+    expect(getDeterministicCompanySnapshotRoute('トヨタの会社概要と過去5年の財務推移を確認して')).toBeNull();
+  });
+});

--- a/src/tools/finance/get-financials.ts
+++ b/src/tools/finance/get-financials.ts
@@ -59,6 +59,481 @@ const FINANCE_TOOLS: StructuredToolInterface[] = [
 
 const FINANCE_TOOL_MAP = new Map(FINANCE_TOOLS.map(t => [t.name, t]));
 
+type PacketDiagnostics = {
+  packetType: 'company_snapshot';
+  sourceTool: 'get_company_info';
+  compacted: boolean;
+  selectedFieldCount: number;
+  fallbackReason?: 'compact_packet_unusable';
+};
+
+type CompanySnapshotRoute = {
+  tool: 'get_company_info';
+  args: { ticker: string };
+};
+
+type FinanceToolCall = {
+  name: string;
+  args: Record<string, unknown>;
+};
+
+type FinanceToolResult = {
+  tool: string;
+  args: Record<string, unknown>;
+  data: unknown;
+  sourceUrls: string[];
+  error: string | null;
+};
+
+type KeyMetric = {
+  label: string;
+  value: unknown;
+  unit: string | null;
+  status: 'available' | 'unavailable';
+  sourceField: string;
+  note?: string;
+};
+
+const COMPANY_INFO_TOP_FIELDS = [
+  'name',
+  'name_ja',
+  'name_en',
+  'sec_code',
+  'edinet_code',
+  'industry',
+  'business_summary',
+  'business_items',
+  'hq_address',
+  'founding_date',
+  'representative_name',
+  'accounting_standard',
+  'latest_fiscal_year',
+  'credit_rating',
+  'credit_score',
+  'data_notes',
+] as const;
+
+const LATEST_EARNINGS_FIELDS = [
+  'title',
+  'disclosure_date',
+  'disclosure_time',
+  'fiscal_year_end',
+  'quarter',
+  'accounting_standard',
+  'revenue',
+  'revenue_change',
+  'operating_income',
+  'operating_income_change',
+  'ordinary_income',
+  'ordinary_income_change',
+  'net_income',
+  'net_income_change',
+  'eps',
+  'dividend_per_share',
+  'forecast_revenue',
+  'forecast_revenue_change',
+  'forecast_operating_income',
+  'forecast_operating_income_change',
+  'forecast_net_income',
+  'forecast_net_income_change',
+  'forecast_eps',
+  'forecast_dividend_per_share',
+] as const;
+
+const LATEST_FINANCIALS_FIELDS = [
+  'fiscal_year',
+  'submit_date',
+  'accounting_standard',
+  'revenue',
+  'operating_income',
+  'ordinary_income',
+  'net_income',
+  'total_assets',
+  'total_liabilities',
+  'net_assets',
+  'shareholders_equity',
+  'cash',
+  'cf_operating',
+  'cf_investing',
+  'cf_financing',
+  'equity_ratio_official',
+  'roe_official',
+  'eps',
+  'diluted_eps',
+  'bps',
+  'per',
+  'pbr',
+  'dividend_per_share',
+  'payout_ratio',
+  'num_employees',
+  'avg_annual_salary',
+  'avg_age',
+  'avg_tenure_years',
+] as const;
+
+function pickFields<T extends readonly string[]>(
+  source: unknown,
+  fields: T,
+): Partial<Record<T[number], unknown>> | undefined {
+  if (!source || typeof source !== 'object') {
+    return undefined;
+  }
+  const record = source as Record<string, unknown>;
+  const picked: Record<string, unknown> = {};
+  for (const field of fields) {
+    if (field in record) {
+      picked[field] = record[field];
+    }
+  }
+  return Object.keys(picked).length > 0
+    ? (picked as Partial<Record<T[number], unknown>>)
+    : undefined;
+}
+
+function getObjectKeyCount(value: unknown): number {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? Object.keys(value as Record<string, unknown>).length
+    : 0;
+}
+
+function withPacketDiagnostics(data: unknown, diagnostics: PacketDiagnostics): unknown {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return data;
+  }
+  return {
+    ...(data as Record<string, unknown>),
+    _packet: diagnostics,
+  };
+}
+
+function isUsableCompanySnapshotPacket(data: unknown): boolean {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return false;
+  }
+  const record = data as Record<string, unknown>;
+  const hasIdentity = COMPANY_INFO_TOP_FIELDS.some((field) => field in record);
+  const hasFinancialData = 'latest_earnings' in record || 'latest_financials' in record;
+  return hasIdentity && hasFinancialData;
+}
+
+function buildKeyMetric(
+  source: Record<string, unknown>,
+  field: string,
+  label: string,
+  unit: string | null,
+): KeyMetric | undefined {
+  if (!(field in source)) {
+    return undefined;
+  }
+  return {
+    label,
+    value: source[field],
+    unit,
+    status: source[field] === null || source[field] === undefined ? 'unavailable' : 'available',
+    sourceField: `latest_financials.${field}`,
+  };
+}
+
+function buildCompanySnapshotKeyMetrics(latestFinancials: unknown): Record<string, KeyMetric> | undefined {
+  if (!latestFinancials || typeof latestFinancials !== 'object' || Array.isArray(latestFinancials)) {
+    return undefined;
+  }
+
+  const record = latestFinancials as Record<string, unknown>;
+  const metrics: Record<string, KeyMetric> = {};
+
+  for (const [key, metric] of [
+    ['revenue', buildKeyMetric(record, 'revenue', 'Revenue / 売上高', 'JPY')],
+    ['operating_income', buildKeyMetric(record, 'operating_income', 'Operating income / 営業利益', 'JPY')],
+    ['net_income', buildKeyMetric(record, 'net_income', 'Net income / 純利益', 'JPY')],
+    ['total_assets', buildKeyMetric(record, 'total_assets', 'Total assets / 総資産', 'JPY')],
+    ['roe', buildKeyMetric(record, 'roe_official', 'ROE (Return on Equity) / 自己資本利益率', '%')],
+    ['equity_ratio', buildKeyMetric(record, 'equity_ratio_official', 'Equity ratio / 自己資本比率', '%')],
+    ['eps', buildKeyMetric(record, 'eps', 'EPS (Earnings per Share) / 1株当たり利益', 'JPY/share')],
+    ['bps', buildKeyMetric(record, 'bps', 'BPS (Book-value per Share) / 1株当たり純資産', 'JPY/share')],
+    ['per', buildKeyMetric(record, 'per', 'PER (Price-to-Earnings Ratio) / 株価収益率', 'x')],
+  ] as const) {
+    if (metric) {
+      metrics[key] = metric;
+    }
+  }
+
+  metrics.pbr = buildKeyMetric(record, 'pbr', 'PBR (Price-to-Book Ratio) / 株価純資産倍率', 'x') ?? {
+    label: 'PBR (Price-to-Book Ratio) / 株価純資産倍率',
+    value: null,
+    unit: 'x',
+    status: 'unavailable',
+    sourceField: 'latest_financials.pbr',
+    note: 'PBR is not available in this company snapshot source. Do not infer PBR from PER.',
+  };
+
+  return Object.keys(metrics).length > 0 ? metrics : undefined;
+}
+
+/**
+ * Keep meta-tool results compact enough for local models while preserving
+ * the metrics users usually ask for in a first company snapshot.
+ */
+export function compactFinanceResult(toolName: string, data: unknown): unknown {
+  if (toolName !== 'get_company_info' || !data || typeof data !== 'object') {
+    return data;
+  }
+
+  const record = data as Record<string, unknown>;
+  const compact: Record<string, unknown> = {
+    ...pickFields(record, COMPANY_INFO_TOP_FIELDS),
+  };
+
+  const latestEarnings = pickFields(record.latest_earnings, LATEST_EARNINGS_FIELDS);
+  if (latestEarnings) {
+    compact.latest_earnings = latestEarnings;
+  }
+
+  const latestFinancials = pickFields(record.latest_financials, LATEST_FINANCIALS_FIELDS);
+  if (latestFinancials) {
+    compact.latest_financials = latestFinancials;
+  }
+
+  const keyMetrics = buildCompanySnapshotKeyMetrics(record.latest_financials);
+  if (keyMetrics) {
+    compact.key_metrics = keyMetrics;
+  }
+
+  const sources = pickFields(record.sources, [
+    'business_items',
+    'founding_date',
+    'hq_address',
+    'representative_name',
+  ] as const);
+  if (sources) {
+    compact.sources = sources;
+  }
+
+  const compactFieldCount = getObjectKeyCount(compact);
+  if (!isUsableCompanySnapshotPacket(compact)) {
+    return withPacketDiagnostics(data, {
+      packetType: 'company_snapshot',
+      sourceTool: 'get_company_info',
+      compacted: false,
+      selectedFieldCount: compactFieldCount,
+      fallbackReason: 'compact_packet_unusable',
+    });
+  }
+
+  return withPacketDiagnostics(compact, {
+    packetType: 'company_snapshot',
+    sourceTool: 'get_company_info',
+    compacted: true,
+    selectedFieldCount: compactFieldCount,
+  });
+}
+
+const SNAPSHOT_OVERVIEW_TERMS = [
+  '会社概要',
+  '企業概要',
+  '会社情報',
+  '企業情報',
+  '基本情報',
+] as const;
+
+const SNAPSHOT_FINANCIAL_TERMS = [
+  '直近',
+  '最新',
+  '主要財務',
+  '主要指標',
+  '財務指標',
+  '財務',
+  '業績',
+  'key ratios',
+  'financials',
+] as const;
+
+const NON_SNAPSHOT_INTENT_TERMS = [
+  '比較',
+  '比べ',
+  '競合',
+  'screening',
+  'screener',
+  'スクリーニング',
+  '抽出',
+  'ランキング',
+  '一覧',
+  '有価証券報告書',
+  'filing',
+  'filings',
+  'read_filings',
+  '決算短信',
+  'earnings',
+  'tdnet',
+  '過去',
+  '推移',
+  'トレンド',
+  '時系列',
+  '履歴',
+  'history',
+  'historical',
+  '財務健全性',
+  '健全性',
+  'スコア',
+  'score',
+  'health',
+  '分析',
+  '財務分析',
+  'analysis',
+  'analyze',
+  'key ratio',
+  'key ratios',
+  'ratio',
+  'ratios',
+  'roic',
+  'roe',
+  '詳しく',
+  '詳細',
+  'detail',
+  'details',
+] as const;
+
+const SNAPSHOT_COMPANY_ALIAS_TO_TICKER: Record<string, string> = {
+  トヨタ: '7203',
+};
+
+function includesAny(query: string, terms: readonly string[]): boolean {
+  const normalizedQuery = query.toLowerCase();
+  return terms.some((term) => normalizedQuery.includes(term.toLowerCase()));
+}
+
+function normalizeSnapshotTicker(ticker: string): string {
+  return SNAPSHOT_COMPANY_ALIAS_TO_TICKER[ticker] ?? '';
+}
+
+function stripSnapshotYears(text: string): string {
+  return text.replace(/(?:の)?\d{4}\s*年(?:度)?(?:の)?/gu, '');
+}
+
+function getSnapshotSubject(query: string): string | null {
+  const beforeOverview = query.match(/^(.{1,60}?)(?:の)?(?:会社概要|企業概要|会社情報|企業情報|基本情報)/u)?.[1];
+  if (!beforeOverview) {
+    return null;
+  }
+
+  return stripSnapshotYears(
+    beforeOverview.replace(/^(?:まず|簡単に|ざっくり|短く|一言で)\s*/u, ''),
+  ).trim();
+}
+
+function containsSubjectSeparator(subject: string): boolean {
+  return /(?:と|、|,|＆|&|\bvs\b|及び|および)/iu.test(subject);
+}
+
+function hasOnlyIdentifierSubject(subject: string, identifier: string): boolean {
+  const remaining = subject
+    .replaceAll(identifier, '')
+    .replace(/[()\[\]{}（）【】「」『』\s]/gu, '')
+    .replace(/^の|の$/gu, '');
+  return remaining.length === 0;
+}
+
+function extractSnapshotTicker(query: string): string | null {
+  const subject = getSnapshotSubject(query);
+  if (!subject || containsSubjectSeparator(subject)) {
+    return null;
+  }
+
+  const edinetCodes = [...new Set(query.match(/\bE\d{5}\b/gi) ?? [])];
+  const securitiesCodes = [...new Set(
+    [...query.matchAll(/\b(\d{4})\b(?!\s*(?:年(?:度)?|億(?:円)?|万円|円))/g)]
+      .map((match) => match[1])
+      .filter((code): code is string => Boolean(code)),
+  )];
+
+  if (edinetCodes.length > 1) {
+    return null;
+  }
+  if (securitiesCodes.length > 1) {
+    return null;
+  }
+  if (edinetCodes.length > 0 && securitiesCodes.length > 0) {
+    return null;
+  }
+
+  const edinetCode = edinetCodes[0];
+  if (edinetCode) {
+    return hasOnlyIdentifierSubject(subject, edinetCode) ? edinetCode : null;
+  }
+
+  const securitiesCode = securitiesCodes[0];
+  if (securitiesCode) {
+    return hasOnlyIdentifierSubject(subject, securitiesCode) ? securitiesCode : null;
+  }
+
+  const normalizedTicker = normalizeSnapshotTicker(subject);
+  return normalizedTicker.length > 0 ? normalizedTicker : null;
+}
+
+export function getDeterministicCompanySnapshotRoute(query: string): CompanySnapshotRoute | null {
+  if (
+    !includesAny(query, SNAPSHOT_OVERVIEW_TERMS)
+    || !includesAny(query, SNAPSHOT_FINANCIAL_TERMS)
+    || includesAny(query, NON_SNAPSHOT_INTENT_TERMS)
+  ) {
+    return null;
+  }
+
+  const ticker = extractSnapshotTicker(query);
+  return ticker ? { tool: 'get_company_info', args: { ticker } } : null;
+}
+
+async function executeFinanceToolCall(tc: FinanceToolCall): Promise<FinanceToolResult> {
+  try {
+    const tool = FINANCE_TOOL_MAP.get(tc.name);
+    if (!tool) {
+      throw new Error(`Tool '${tc.name}' not found`);
+    }
+    const rawResult = await withTimeout(tool.invoke(tc.args), SUB_TOOL_TIMEOUT_MS, tc.name);
+    const result = typeof rawResult === 'string' ? rawResult : JSON.stringify(rawResult);
+    const parsed = JSON.parse(result) as { data?: unknown; sourceUrls?: unknown };
+    const compactData = compactFinanceResult(tc.name, parsed.data);
+    return {
+      tool: tc.name,
+      args: tc.args,
+      data: compactData,
+      sourceUrls: Array.isArray(parsed.sourceUrls) ? parsed.sourceUrls.filter((url): url is string => typeof url === 'string') : [],
+      error: null,
+    };
+  } catch (error) {
+    return {
+      tool: tc.name,
+      args: tc.args,
+      data: null,
+      sourceUrls: [],
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function formatFinanceToolResults(results: FinanceToolResult[]): string {
+  const successfulResults = results.filter((r) => r.error === null);
+  const failedResults = results.filter((r) => r.error !== null);
+  const allUrls = results.flatMap((r) => r.sourceUrls);
+
+  const combinedData: Record<string, unknown> = {};
+  for (const result of successfulResults) {
+    const ticker = result.args.ticker as string | undefined;
+    const key = ticker ? `${result.tool}_${ticker}` : result.tool;
+    combinedData[key] = result.data;
+  }
+
+  if (failedResults.length > 0) {
+    combinedData._errors = failedResults.map((r) => ({
+      tool: r.tool,
+      args: r.args,
+      error: r.error,
+    }));
+  }
+
+  return formatToolResult(combinedData, allUrls);
+}
+
 function buildRouterPrompt(): string {
   return `You are a Japanese financial data routing assistant.
 Current date: ${getCurrentDate()}
@@ -110,6 +585,16 @@ export function createGetFinancials(model: string): DynamicStructuredTool {
       const onProgress = config?.metadata?.onProgress as ((msg: string) => void) | undefined;
 
       onProgress?.('Fetching...');
+      const deterministicRoute = getDeterministicCompanySnapshotRoute(input.query);
+      if (deterministicRoute) {
+        onProgress?.(`Fetching from ${formatSubToolName(deterministicRoute.tool)}...`);
+        const result = await executeFinanceToolCall({
+          name: deterministicRoute.tool,
+          args: deterministicRoute.args,
+        });
+        return formatFinanceToolResults([result]);
+      }
+
       const { response } = await callLlm(input.query, {
         model,
         systemPrompt: buildRouterPrompt(),
@@ -125,54 +610,13 @@ export function createGetFinancials(model: string): DynamicStructuredTool {
       const toolNames = [...new Set(toolCalls.map(tc => formatSubToolName(tc.name)))];
       onProgress?.(`Fetching from ${toolNames.join(', ')}...`);
       const results = await Promise.all(
-        toolCalls.map(async (tc) => {
-          try {
-            const tool = FINANCE_TOOL_MAP.get(tc.name);
-            if (!tool) {
-              throw new Error(`Tool '${tc.name}' not found`);
-            }
-            const rawResult = await withTimeout(tool.invoke(tc.args), SUB_TOOL_TIMEOUT_MS, tc.name);
-            const result = typeof rawResult === 'string' ? rawResult : JSON.stringify(rawResult);
-            const parsed = JSON.parse(result);
-            return {
-              tool: tc.name,
-              args: tc.args,
-              data: parsed.data,
-              sourceUrls: parsed.sourceUrls || [],
-              error: null,
-            };
-          } catch (error) {
-            return {
-              tool: tc.name,
-              args: tc.args,
-              data: null,
-              sourceUrls: [],
-              error: error instanceof Error ? error.message : String(error),
-            };
-          }
-        })
+        toolCalls.map((tc) => executeFinanceToolCall({
+          name: tc.name,
+          args: tc.args as Record<string, unknown>,
+        }))
       );
 
-      const successfulResults = results.filter((r) => r.error === null);
-      const failedResults = results.filter((r) => r.error !== null);
-      const allUrls = results.flatMap((r) => r.sourceUrls);
-
-      const combinedData: Record<string, unknown> = {};
-      for (const result of successfulResults) {
-        const ticker = (result.args as Record<string, unknown>).ticker as string | undefined;
-        const key = ticker ? `${result.tool}_${ticker}` : result.tool;
-        combinedData[key] = result.data;
-      }
-
-      if (failedResults.length > 0) {
-        combinedData._errors = failedResults.map((r) => ({
-          tool: r.tool,
-          args: r.args,
-          error: r.error,
-        }));
-      }
-
-      return formatToolResult(combinedData, allUrls);
+      return formatFinanceToolResults(results);
     },
   });
 }

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -23,6 +23,7 @@ const PROVIDER_MODELS: Record<string, Model[]> = {
     { id: 'claude-opus-4-7', displayName: 'Opus 4.7' },
   ],
   google: [
+    { id: 'gemma-4-31b-it', displayName: 'Gemma 4 31B IT' },
     { id: 'gemini-3-flash-preview', displayName: 'Gemini 3 Flash' },
     { id: 'gemini-3.1-pro-preview', displayName: 'Gemini 3.1 Pro' },
   ],


### PR DESCRIPTION
## 概要

Issue #6 のPhase 1として、無料枠・低コストLLMでも会社snapshot調査が詰まりにくいようにしました。

- CLIで同じqueryが複数回表示される増分描画バグを修正
- `gemma-*` モデルをGoogle providerへroutingし、`gemma-4-31b-it` を `/model` 候補に追加
- `get_financials` に会社概要 + 直近財務向けの保守的なdeterministic routeを追加
- `get_company_info` の巨大JSONをcompact company snapshot packetへ圧縮
- `_packet` diagnostics と `key_metrics` を追加し、PER/PBRなどを低コストLLMが誤読しにくい形に変更
- focused testsを追加

## 設計メモ

Deterministic routeは安全側に限定しています。

- route対象: 4桁証券コード、EDINETコード、whitelist alias（現時点では `トヨタ` → `7203`）
- fallback対象: `ソニー` / `三菱` などwhitelist外の裸社名、比較、screening、filings、earnings、過去推移、numeric amount混入query

これにより、曖昧な自然言語補正は従来通りLLM routerへ任せ、明確なsnapshot queryだけ高速化します。

## 検証

```bash
bun test src/tools/finance/get-financials.test.ts
bun run typecheck
bun test
```

結果:

- focused tests: 9 pass
- typecheck: pass
- full tests: 46 pass

追加確認:

- route helper smokeで以下を確認
  - `7203とホンダ...` → `null`
  - `E02144と7267...` → `null`
  - `売上高1000億円...` → `null`
  - `7203...` → `get_company_info({ ticker: "7203" })`
  - `E02144...` → `get_company_info({ ticker: "E02144" })`
  - `トヨタの2025年...` → `get_company_info({ ticker: "7203" })`
- `gemma-4-31b-it` のlive Agent smokeで最終回答まで返ることを確認

## Review

Issue #6 上でClaude reviewとCodex Final Reviewerを実施済みです。

- Claude follow-up review: https://github.com/edinetdb/dexter-jp/issues/6#issuecomment-4640793610
- Codex Final Reviewer: P2/P3を修正後、再レビューでno findings

Closes #6
