### PR TITLE
fix: 識別子の検証 + 廃止企業の明示 (resolver/prompts)

### DIFF
--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -254,6 +254,8 @@ ${toolDescriptions}
 - Only use web_fetch when headlines are insufficient (need quotes, deal specifics, earnings details).
 - Only use browser when you need JavaScript rendering or interactive navigation.
 - Tool results are automatically capped. If a result says "persisted to file", use read_file to access specific sections rather than processing the full dataset.
+- Identifier integrity: any securities code (e.g. 7203) or EDINET code (e.g. E02144) you put in your answer MUST come from a tool result (get_company_info / get_financial_statements / search), never from memory. If you are unsure of a code, look it up first or omit it — never guess a code.
+- Listing status: before presenting a company as currently listed or as a current/future candidate (e.g. a takeover target), verify its listing status. If a tool result shows is_delisted=true (or listing_status="delisted"), state explicitly that the company is delisted and do not present it as an active company or current investment candidate.
 - For factual questions about entities, use tools to verify current state.
 - Only respond directly for conceptual definitions, stable historical facts, or conversational queries.
 - Respond in the same language the user uses (Japanese or English).

--- a/src/tools/finance/resolver.ts
+++ b/src/tools/finance/resolver.ts
@@ -7,6 +7,117 @@ import { logger } from '../../utils/logger.js';
  */
 const codeCache = new Map<string, string>();
 
+export interface ResolvedCompany {
+  edinetCode: string;
+  name: string;
+  secCode: string;
+  /** true when EDINET DB marks the company non-listed (delisted). */
+  isDelisted: boolean;
+  /** 'listed' | 'delisted' | 'unknown' (from EDINET DB listing_status). */
+  listingStatus: string;
+}
+
+interface SearchHit {
+  edinet_code: string;
+  name: string;
+  name_ja?: string;
+  name_en?: string;
+  sec_code: string;
+  is_delisted?: boolean;
+  listing_status?: string;
+}
+
+function normalize(s: string | undefined): string {
+  return (s ?? '').normalize('NFKC').toLowerCase().trim();
+}
+
+/** A securities-code-shaped query like "7203" or "135A" (4 digits + optional char). */
+function isSecCodeQuery(key: string): boolean {
+  return /^[0-9]{4}[0-9A-Za-z]?$/.test(key);
+}
+
+function isHitDelisted(h: SearchHit): boolean {
+  return h.is_delisted === true || h.listing_status === 'delisted';
+}
+
+/**
+ * Pick the best-matching hit for the query rather than blindly taking the first
+ * result. The old `limit:1` + take-first behavior could return the wrong company
+ * (e.g. resolving to a company whose code does not match the queried name). We
+ * verify the match, and prefer a currently-listed company over a delisted one so
+ * common (listed) resolutions stay stable even though we now search with
+ * include_delisted=1.
+ */
+function pickBestMatch(key: string, hits: SearchHit[]): SearchHit | undefined {
+  if (hits.length === 0) return undefined;
+
+  let pool: SearchHit[];
+  if (isSecCodeQuery(key)) {
+    // EDINET DB sec_code is 5 chars ("7203" → "72030"); match the leading 4.
+    pool = hits.filter(h => {
+      const s = h.sec_code || '';
+      return s === key || s === `${key}0` || s.slice(0, 4) === key.slice(0, 4);
+    });
+  } else {
+    const q = normalize(key);
+    pool = hits.filter(h =>
+      normalize(h.name).includes(q) ||
+      normalize(h.name_ja).includes(q) ||
+      normalize(h.name_en).includes(q));
+  }
+  if (pool.length === 0) pool = hits;
+
+  // Prefer a currently-listed match; fall back to the first (possibly delisted)
+  // so a name that ONLY resolves to a delisted company still resolves — tagged.
+  return pool.find(h => !isHitDelisted(h)) ?? pool[0];
+}
+
+/**
+ * Resolve a ticker (securities code like "7203") or company name to a company,
+ * including its listing status, via /v1/search. Searches with include_delisted=1
+ * so formerly-listed (delisted) companies still resolve, and returns isDelisted
+ * so callers never silently treat a delisted company as currently active.
+ *
+ * Note: is_delisted / listing_status are only present once the EDINET DB API
+ * exposes them; until then isDelisted is false and listingStatus is 'unknown'
+ * (this resolver is forward-compatible and does not depend on deploy order).
+ *
+ * @throws Error if no company matches.
+ */
+export async function resolveCompany(ticker: string): Promise<ResolvedCompany> {
+  const key = ticker.trim();
+
+  const { data: responseData } = await api.get('/search', {
+    q: key,
+    limit: 5,
+    include_delisted: 1,
+  });
+  const hits = (responseData.data as SearchHit[] | undefined) ?? [];
+  const hit = pickBestMatch(key, hits);
+
+  if (!hit) {
+    throw new Error(`Company not found: ${ticker}`);
+  }
+
+  const resolved: ResolvedCompany = {
+    edinetCode: hit.edinet_code,
+    name: hit.name,
+    secCode: hit.sec_code,
+    isDelisted: isHitDelisted(hit),
+    listingStatus: hit.listing_status ?? (hit.is_delisted ? 'delisted' : 'unknown'),
+  };
+
+  if (resolved.isDelisted) {
+    logger.warn(
+      `[Resolver] ${ticker} → ${resolved.edinetCode} (${resolved.name}) is DELISTED ` +
+      `(listing_status=${resolved.listingStatus}) — do not present as currently listed`,
+    );
+  } else {
+    logger.info(`[Resolver] ${ticker} → ${resolved.edinetCode} (${resolved.name})`);
+  }
+  return resolved;
+}
+
 /**
  * Resolve a ticker (securities code like "7203") or company name to an EDINET code.
  * Results are cached in-memory for the session.
@@ -28,25 +139,15 @@ export async function resolveEdinetCode(ticker: string): Promise<string> {
     return codeCache.get(key)!;
   }
 
-  // Search via API — /v1/search returns { data: [{edinet_code, name, sec_code, ...}] }
-  const { data: responseData } = await api.get('/search', { q: key, limit: 1 });
-  const companies = responseData.data as Array<{ edinet_code: string; name: string; sec_code: string }> | undefined;
-
-  if (!companies || companies.length === 0) {
-    throw new Error(`Company not found: ${ticker}`);
-  }
-
-  const edinetCode = companies[0].edinet_code;
-  const secCode = companies[0].sec_code;
+  const resolved = await resolveCompany(key);
 
   // Cache both the original query key and the secCode
-  codeCache.set(key, edinetCode);
-  if (secCode && secCode !== key) {
-    codeCache.set(secCode, edinetCode);
+  codeCache.set(key, resolved.edinetCode);
+  if (resolved.secCode && resolved.secCode !== key) {
+    codeCache.set(resolved.secCode, resolved.edinetCode);
   }
 
-  logger.info(`[Resolver] ${ticker} → ${edinetCode} (${companies[0].name})`);
-  return edinetCode;
+  return resolved.edinetCode;
 }
 
 /**


### PR DESCRIPTION
## 背景
@ChokoPltnm の報告: Dexter が廃止済みの NECネッツエスアイ(1973)を現役のTOB候補として挙げ、信越ポリマーに 4118(= カネカの証券コード)を当てて誤表示した。真因は2つ:
1. resolver が `/v1/search` の `limit:1` 先頭を無検証で採用(社名と返り値を照合しない)→ 証券コード取り違え。
2. 上場状態の検証が皆無 → 廃止企業を現役扱い。加えて LLM が回答テキストに記憶のコードを直接書く経路。

## 変更
- **resolver.ts**: `resolveCompany()` 新設。`/v1/search?include_delisted=1` で廃止企業も解決しつつ、社名contains / 証券コードで照合し現役を優先、`isDelisted`/`listingStatus` を返す。`resolveEdinetCode` は委譲。EDINET DB が is_delisted を露出する前後どちらでも動く forward-compatible。
- **prompts.ts**: Tool Usage Policy に2点 — (1) 回答に出す証券/EDINETコードは必ずツール解決値から(記憶禁止)、(2) 現役扱いの前に上場状態を検証し is_delisted=true は廃止を明示。

## 検証
typecheck clean (`tsc --noEmit`) / 既存 37 tests pass。

EDINET DB 側(API に listing_status/is_delisted 露出)は本番反映済み: Cabocia/edinet-db#162。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
