### PR TITLE
release: v2026.6.9-jp — 本家 virattt/dexter v2026.6.9 追従

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexter-jp",
-  "version": "2026.6.3-jp",
+  "version": "2026.6.9-jp",
   "description": "Dexter JP - AI agent for deep financial research on Japanese listed companies. Powered by EDINET DB.",
   "license": "MIT",
   "type": "module",

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -21,6 +21,7 @@ const PROVIDER_MODELS: Record<string, Model[]> = {
     { id: 'claude-sonnet-4-6', displayName: 'Sonnet 4.6' },
     { id: 'claude-opus-4-8', displayName: 'Opus 4.8' },
     { id: 'claude-opus-4-7', displayName: 'Opus 4.7' },
+    { id: 'claude-fable-5', displayName: 'Fable 5' },
   ],
   google: [
     { id: 'gemini-3-flash-preview', displayName: 'Gemini 3 Flash' },


### PR DESCRIPTION
## Summary

本家 [virattt/dexter](https://github.com/virattt/dexter) の v2026.6.9 (2026-06-10) に追従。

- Claude Fable 5 model 追加 (upstream 54712e5)
- version bump `2026.6.3-jp` → `2026.6.9-jp`

Tag: `v2026.6.9-jp` 発行済

## Note on v1.0.0

Upstream v1.0.0 は `ask_user_question` tool (interactive CLI prompts) を追加しているが、JP 側の CLI 実装 (`searchSelection`, `WorkingIndicatorComponent`, `TurnStats` 等) との conflict が大きく、別 PR で対応。

Ref branch: `feat/upstream-sync-v1-0-0` (WIP、cherry-pick 途中で conflict あり)

## Test plan

- [x] `bun run typecheck` パス
- [x] `bun test` 37 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)