### PR TITLE
feat: add You.com Search API as web search provider

### DIFF
--- a/env.example
+++ b/env.example
@@ -46,6 +46,7 @@ EXASEARCH_API_KEY=your-exa-api-key
 PERPLEXITY_API_KEY=your-perplexity-api-key
 TAVILY_API_KEY=your-tavily-api-key
 LANGSEARCH_API_KEY=your-langsearch-api-key
+YOUCOM_API_KEY=your-youcom-api-key
 
 # X/Twitter API (enables x_search tool for public sentiment research)
 X_BEARER_TOKEN=your-X-bearer-token

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -1,6 +1,6 @@
 import { StructuredToolInterface } from '@langchain/core/tools';
 import { createGetFinancials, createReadFilings, createScreenCompanies, getStockPrice, isJQuantsAvailable, STOCK_PRICE_DESCRIPTION } from './finance/index.js';
-import { exaSearch, perplexitySearch, tavilySearch, langSearch, WEB_SEARCH_DESCRIPTION, xSearchTool, X_SEARCH_DESCRIPTION } from './search/index.js';
+import { exaSearch, perplexitySearch, tavilySearch, langSearch, youSearch, WEB_SEARCH_DESCRIPTION, xSearchTool, X_SEARCH_DESCRIPTION } from './search/index.js';
 import { createWebSearchTool, type WebSearchProvider } from './search/web-search.js';
 import { getSetting } from '../utils/config.js';
 import type { SearchProviderId } from '../utils/env.js';
@@ -177,6 +177,9 @@ export function getToolRegistry(model: string): RegisteredTool[] {
   }
   if (process.env.LANGSEARCH_API_KEY) {
     allWebSearchProviders.push({ id: 'langsearch', name: 'LangSearch', tool: langSearch });
+  }
+  if (process.env.YOUCOM_API_KEY) {
+    allWebSearchProviders.push({ id: 'you', name: 'You.com', tool: youSearch });
   }
 
   if (allWebSearchProviders.length > 0) {

--- a/src/tools/search/index.ts
+++ b/src/tools/search/index.ts
@@ -30,4 +30,5 @@ export { tavilySearch } from './tavily.js';
 export { exaSearch } from './exa.js';
 export { perplexitySearch } from './perplexity.js';
 export { langSearch } from './langsearch.js';
+export { youSearch } from './you.js';
 export { xSearchTool, X_SEARCH_DESCRIPTION } from './x-search.js';

--- a/src/tools/search/you.ts
+++ b/src/tools/search/you.ts
@@ -1,0 +1,67 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+import { formatToolResult, parseSearchResults } from '../types.js';
+import { logger } from '@/utils';
+
+const YOU_API_BASE = 'https://api.you.com/v1';
+
+interface YouSearchResponse {
+  results?: Array<{ url: string; title?: string; snippet?: string }>;
+  agent_results?: Array<{ url: string; title?: string; snippet?: string }>;
+}
+
+function parseYouSearchResponse(response: unknown): { parsed: unknown; urls: string[] } {
+  const parsed = response as YouSearchResponse;
+  let urls: string[] = [];
+
+  // You.com returns results in agent_results or results field
+  const results = parsed?.agent_results ?? parsed?.results ?? [];
+  if (Array.isArray(results)) {
+    urls = results
+      .map((r) => r.url)
+      .filter((url): url is string => Boolean(url));
+  }
+
+  return { parsed: response, urls };
+}
+
+export const youSearch = new DynamicStructuredTool({
+  name: 'web_search',
+  description:
+    'Search the web for current information on any topic. Returns relevant search results with URLs and content snippets.',
+  schema: z.object({
+    query: z.string().describe('The search query to look up on the web'),
+  }),
+  func: async (input) => {
+    try {
+      const apiKey = process.env.YOUCOM_API_KEY;
+      if (!apiKey) {
+        throw new Error('YOUCOM_API_KEY is not set');
+      }
+
+      const url = new URL(`${YOU_API_BASE}/agents/search`);
+      url.searchParams.set('input', input.query);
+      url.searchParams.set('num_results', '5');
+
+      const response = await fetch(url.toString(), {
+        headers: {
+          'X-Api-Key': apiKey,
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`You.com API error: ${response.status} ${errorText}`);
+      }
+
+      const result = await response.json();
+      const { parsed, urls } = parseYouSearchResponse(result);
+      return formatToolResult(parsed, urls);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(`[You.com API] error: ${message}`);
+      throw new Error(`[You.com API] ${message}`);
+    }
+  },
+});

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -100,13 +100,14 @@ export function saveApiKeyForProvider(providerId: string, apiKey: string): boole
   return saveApiKeyToEnv(apiKeyName, apiKey);
 }
 
-export type SearchProviderId = 'exa' | 'perplexity' | 'tavily' | 'langsearch';
+export type SearchProviderId = 'exa' | 'perplexity' | 'tavily' | 'langsearch' | 'you';
 
 export const SEARCH_PROVIDERS: Record<SearchProviderId, { displayName: string; apiKeyEnvVar: string }> = {
   exa: { displayName: 'Exa', apiKeyEnvVar: 'EXASEARCH_API_KEY' },
   perplexity: { displayName: 'Perplexity', apiKeyEnvVar: 'PERPLEXITY_API_KEY' },
   tavily: { displayName: 'Tavily', apiKeyEnvVar: 'TAVILY_API_KEY' },
   langsearch: { displayName: 'LangSearch', apiKeyEnvVar: 'LANGSEARCH_API_KEY' },
+  you: { displayName: 'You.com', apiKeyEnvVar: 'YOUCOM_API_KEY' },
 };
 
 export function getSearchProviderDisplayName(providerId: SearchProviderId): string {


### PR DESCRIPTION
## Summary
- Add You.com Search API (`api.you.com/v1/agents/search`) as an alternative web search provider
- Activated via `YOUCOM_API_KEY` environment variable
- Joins existing providers: Exa, Perplexity, Tavily, LangSearch

## Changes
- **src/tools/search/you.ts** — New You.com search provider implementation
- **src/tools/search/index.ts** — Export the new provider
- **src/tools/registry.ts** — Register provider when `YOUCOM_API_KEY` is set
- **src/utils/env.ts** — Add `'you'` to `SearchProviderId` type and `SEARCH_PROVIDERS` record
- **env.example** — Add `YOUCOM_API_KEY` example

## Test Plan
1. Set `YOUCOM_API_KEY=your-key` in `.env`
2. Verify no TypeScript errors: `npm run typecheck`
3. Run `bun run start` and query with `/search` using You.com as provider
4. Confirm search results return successfully

🤖 Generated with [Claude Code](https://claude.ai/claude-code)