### PR TITLE
release: v1.0.0-jp — 本家 v1.0.0 追従 + Claude Agent SDK モード

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -193,6 +193,21 @@ Switch models on the fly with the `/model` command:
 - xAI (Grok)
 - OpenRouter
 - Ollama (local LLMs)
+- Claude Agent SDK (see below)
+
+### Claude Agent SDK mode
+
+A run mode powered by `@anthropic-ai/claude-agent-sdk`. The agent loop is delegated to the SDK, and **authentication is resolved by the SDK** — Dexter implements no auth flow of its own.
+
+- Pick the **Claude Agent SDK** provider via `/model`, choose a model (claude-fable-5 / claude-opus-4-8 / claude-sonnet-4-6), and go. No API key entry is requested.
+- The SDK resolves credentials. It works with your **Claude Code login**, `CLAUDE_CODE_OAUTH_TOKEN`, or `ANTHROPIC_API_KEY` — the SDK decides which, based on your environment.
+- Whether the Agent SDK can be used on a Claude plan (Pro/Max), and under what terms, is described in Anthropic's help ([Use the Claude Agent SDK with your Claude plan](https://support.claude.com/en/articles/15036540)). Terms may change.
+- Use it with your own personal credentials only; do not offer it as a multi-user service.
+- **Billing-path check**: if a usage-based credential (`ANTHROPIC_API_KEY`, `CLAUDE_CODE_USE_BEDROCK`, `CLAUDE_CODE_USE_VERTEX`, …) is present in the environment, the mode reports what it detected at startup and stops before running so it does not proceed on an unintended billing path (fail-loud). To proceed on that path, set `DEXTER_AGENT_SDK_ALLOW_METERED=1` and retry.
+- To cap cost, set `DEXTER_AGENT_SDK_MAX_BUDGET_USD` (USD); the SDK stops when its estimate reaches it.
+- In this mode Dexter's finance/data tools return raw data for the main model to interpret (no internal LLM re-call inside tools). SDK built-in tools (Bash / Write / WebSearch, etc.) are not used.
+
+> Note: availability and pricing of this mode depend on Anthropic's terms and may change. This does not claim the mode is "free" or "no extra cost"; the startup line shows which credential path is actually in use.
 
 ### Messaging Integrations
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,21 @@ CLIで `/rules` と入力すると現在のルールを確認できる。
 - xAI（Grok）
 - OpenRouter
 - Ollama（ローカルLLM）
+- Claude Agent SDK（後述）
+
+### Claude Agent SDK モード
+
+`@anthropic-ai/claude-agent-sdk` 経由で動く実行モード。エージェントのループを SDK に委譲し、**認証は SDK が解決する**（Dexter は認証フローを実装しない）。
+
+- `/model` で **Claude Agent SDK** プロバイダを選び、モデル（claude-fable-5 / claude-opus-4-8 / claude-sonnet-4-6）を選ぶだけで使える。API キーの入力は求められない。
+- 認証は SDK が解決する。**Claude Code のログイン**、`CLAUDE_CODE_OAUTH_TOKEN`、`ANTHROPIC_API_KEY` のいずれでも動作する。どれが使われるかは SDK が環境から判断する。
+- Claude プラン（Pro/Max）で Agent SDK を利用できるかの条件は Anthropic の公式ヘルプを参照（[Use the Claude Agent SDK with your Claude plan](https://support.claude.com/en/articles/15036540)）。制度は変更される可能性がある。
+- 個人の資格情報でのみ使うこと。マルチユーザー向けサービスとして提供しない。
+- **課金経路の確認**: `ANTHROPIC_API_KEY` や `CLAUDE_CODE_USE_BEDROCK` / `CLAUDE_CODE_USE_VERTEX` など従量課金の資格情報が環境にある場合、起動時に検出結果を表示し、意図しない課金経路で走らないよう停止する（fail-loud）。その経路で実行したい場合は `DEXTER_AGENT_SDK_ALLOW_METERED=1` を設定して再実行する。
+- コスト上限を設けたい場合は `DEXTER_AGENT_SDK_MAX_BUDGET_USD`（USD）を設定する。SDK 側の見積りがこの値に達すると停止する。
+- このモードでは Dexter の財務・データツールを「そのままのデータを返す」形で SDK に渡し、メインモデル自身が解釈する（ツール内部で LLM を再呼び出ししない）。SDK 組み込みのツール（Bash / Write / WebSearch 等）は使わない。
+
+> 注: 本モードの利用可否・料金は Anthropic 側の仕様変更に依存する。ここでは「無料」「追加課金なし」といった断定はしない。実際にどの資格情報が使われるかは起動時の表示で確認できる。
 
 ### メッセージング連携
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "dexter-ts",
       "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "0.3.195",
         "@langchain/anthropic": "^1.3.25",
         "@langchain/core": "^1.1.36",
         "@langchain/exa": "^1.0.1",
@@ -50,6 +51,24 @@
     },
   },
   "packages": {
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.195", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.195", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.195", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.195", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.195", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.195", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.195", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.195", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.195" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-FVmXu9pvOMbuBKWrF8YsYQdQ/upOpv5rS8lFAnFO5jbyXT/2hN7kEPd2vd2GJpaMvNcO/KptyQUK5AxjjTz3+w=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.195", "", { "os": "darwin", "cpu": "arm64" }, "sha512-WIMM/8HRCLsTDHFTIwQvvE8WCA/oaMJtdQxsP7iNyfzIGwXbuOyU95V8vYIhZfaO2yaSpbBRncunq4CtR5H4ng=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.195", "", { "os": "darwin", "cpu": "x64" }, "sha512-RY7DB+4LXosE0MJ+XELmakfPrDN1YX4lkk9CTDm28jGCVcESRz9kAEqbyaiC48dZcmN9V1NCLutzINGdcr1TBg=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.195", "", { "os": "linux", "cpu": "arm64" }, "sha512-JuIq5Fnz/F1snl0aqi1gcuRZqPWoPNrL9dJ0DuievCxKkO8hnEz/Mmn5Zos7x1X8HE//ZnEvmQXoEQEZXonJew=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.195", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZmyBA/AFzhgutcxb7dbhCm6GTjJytwNYXTxJoKE2B3A409WCYccjMqeji6vCMNxyyfylglGo5D8dVMIxW9aoug=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.195", "", { "os": "linux", "cpu": "x64" }, "sha512-s1lNi1cL93luoqsItH+fNO4KpIhdkvnVhWGGQUQ/8ftwa2gfmcIQnOg1hG8Ks+KzeD3UUQ8L9YEVHVADnFI/9A=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.195", "", { "os": "linux", "cpu": "x64" }, "sha512-nf8Q/LauB+ZOC6QDjxNhbsvwUtYjKYnaWJLTYFwhkmsLujePnety1AtT/1ubaUoq5AM1j297DhMlYTasa79OUA=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.195", "", { "os": "win32", "cpu": "arm64" }, "sha512-hbkDE+xPIZzRWm+D+BKrH9uJH6USIZdDIlsyrIlGi3JFHoieYoA1vdUNyldSS9+F3ZqQtfPjr2Qy08IVB6akYA=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.195", "", { "os": "win32", "cpu": "x64" }, "sha512-av0piEB3X1Dzhpr8A+DqHVZ9y8s1jpn8enzwX0TKKUPBn5IqLTWC7wD6v66aoUgu4f+g4ThZirmDZA6shyPEZQ=="],
+
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.74.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-srbJV7JKsc5cQ6eVuFzjZO7UR3xEPJqPamHFIe29bs38Ij2IripoAhC0S5NslNbaFUYqBKypmmpzMTpqfHEUDw=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
@@ -348,6 +367,8 @@
 
     "@hapi/hoek": ["@hapi/hoek@9.3.0", "", {}, "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="],
 
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
     "@img/colour": ["@img/colour@1.0.0", "", {}, "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="],
 
     "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
@@ -465,6 +486,8 @@
     "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.52.12", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "marked": "^15.0.12", "mime-types": "^3.0.1" } }, "sha512-QQ4LUlAYKN2BvT3EMU63+kYLlIkyr706+rUFBGWvkiT8ZyMy5if3oaVJpO5qAndsMB+MaUnttIBPh3iHiaJ01g=="],
 
     "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@mozilla/readability": ["@mozilla/readability@0.6.0", "", {}, "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ=="],
 
@@ -596,6 +619,10 @@
 
     "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
     "ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
@@ -716,6 +743,8 @@
 
     "core-js-compat": ["core-js-compat@3.49.0", "", { "dependencies": { "browserslist": "^4.28.1" } }, "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA=="],
 
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
     "create-jest": ["create-jest@29.7.0", "", { "dependencies": { "@jest/types": "^29.6.3", "chalk": "^4.0.0", "exit": "^0.1.2", "graceful-fs": "^4.2.9", "jest-config": "^29.7.0", "jest-util": "^29.7.0", "prompts": "^2.0.1" }, "bin": { "create-jest": "bin/create-jest.js" } }, "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q=="],
 
     "croner": ["croner@9.1.0", "", {}, "sha512-p9nwwR4qyT5W996vBZhdvBCnMhicY5ytZkR4D1Xj0wuTDEiMnjwR57Q3RXYY/s0EpX6Ay3vgIcfaR+ewGHsi+g=="],
@@ -814,6 +843,10 @@
 
     "eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
+
     "exa-js": ["exa-js@2.10.1", "", { "dependencies": { "cross-fetch": "~4.1.0", "dotenv": "~16.4.7", "openai": "^5.0.1", "zod": "^3.22.0", "zod-to-json-schema": "^3.20.0" } }, "sha512-dmwkep7QYBVd0cJBPqlgqpeK3bbICixWmzxJLHKFkUBCvRa89GC1WEe6CxdHWPTP3BeVrNtiQRFnz6z9dGy60w=="],
 
     "execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
@@ -826,11 +859,15 @@
 
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
+    "express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
+
     "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-uri": ["fast-uri@3.1.3", "", {}, "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg=="],
 
     "fb-watchman": ["fb-watchman@2.0.2", "", { "dependencies": { "bser": "2.1.1" } }, "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA=="],
 
@@ -898,6 +935,8 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
+    "hono": ["hono@4.12.27", "", {}, "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q=="],
+
     "hookified": ["hookified@1.15.1", "", {}, "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg=="],
 
     "html-escaper": ["html-escaper@3.0.3", "", {}, "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="],
@@ -923,6 +962,8 @@
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
@@ -1008,6 +1049,8 @@
 
     "jest-worker": ["jest-worker@30.3.0", "", { "dependencies": { "@types/node": "*", "@ungap/structured-clone": "^1.3.0", "jest-util": "30.3.0", "merge-stream": "^2.0.0", "supports-color": "^8.1.1" } }, "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ=="],
 
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+
     "js-tiktoken": ["js-tiktoken@1.0.21", "", { "dependencies": { "base64-js": "^1.5.1" } }, "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
@@ -1019,6 +1062,10 @@
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
 
     "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
@@ -1134,6 +1181,8 @@
 
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
     "ollama": ["ollama@0.6.3", "", { "dependencies": { "whatwg-fetch": "^3.6.20" } }, "sha512-KEWEhIqE5wtfzEIZbDCLH51VFZ6Z3ZSa6sIOg/E/tBV8S51flyqBOXi+bRxlOYKDf8i327zG9eSTb8IJxvm3Zg=="],
@@ -1187,6 +1236,8 @@
     "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
 
     "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "pkg-dir": ["pkg-dir@4.2.0", "", { "dependencies": { "find-up": "^4.0.0" } }, "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ=="],
 
@@ -1243,6 +1294,8 @@
     "regjsparser": ["regjsparser@0.13.0", "", { "dependencies": { "jsesc": "~3.1.0" }, "bin": { "regjsparser": "bin/parser" } }, "sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 

--- a/env.example
+++ b/env.example
@@ -10,6 +10,18 @@ DEEPSEEK_API_KEY=your-deepseek-api-key
 # Ollama (Local LLM)
 OLLAMA_BASE_URL=http://127.0.0.1:11434
 
+# Claude Agent SDK mode
+# Select the "Claude Agent SDK" provider via /model — no API key entry is required
+# here; the SDK resolves credentials itself (Claude Code login / CLAUDE_CODE_OAUTH_TOKEN
+# / ANTHROPIC_API_KEY). See README "Claude Agent SDK モード".
+# If a usage-based credential path (ANTHROPIC_API_KEY / CLAUDE_CODE_USE_BEDROCK /
+# CLAUDE_CODE_USE_VERTEX / ...) is present in the environment, the mode stops before
+# running and reports it. Set this to 1 to explicitly proceed on that path.
+DEXTER_AGENT_SDK_ALLOW_METERED=0
+# Optional client-side cost ceiling (USD) for Claude Agent SDK mode; the SDK stops
+# when its estimate reaches this value. Leave unset for no ceiling.
+# DEXTER_AGENT_SDK_MAX_BUDGET_USD=1.00
+
 # Persistent memory embeddings reuse existing model API keys.
 # Priority: OpenAI (OPENAI_API_KEY) -> Gemini (GOOGLE_API_KEY) -> Ollama (OLLAMA_BASE_URL)
 # No additional memory-specific API keys required.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexter-jp",
-  "version": "2026.6.9-jp",
+  "version": "1.0.0-jp",
   "description": "Dexter JP - AI agent for deep financial research on Japanese listed companies. Powered by EDINET DB.",
   "license": "MIT",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "postinstall": "playwright install chromium"
   },
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "0.3.195",
     "@langchain/anthropic": "^1.3.25",
     "@langchain/core": "^1.1.36",
     "@langchain/exa": "^1.0.1",

--- a/scripts/agent-sdk-auth-poc.ts
+++ b/scripts/agent-sdk-auth-poc.ts
@@ -1,0 +1,119 @@
+/**
+ * Phase 1 auth PoC for the Claude Agent SDK mode.
+ *
+ * Purpose: establish the technical fact of whether `@anthropic-ai/claude-agent-sdk`
+ * runs on this machine's Claude Code login credentials (OAuth), with NO
+ * `ANTHROPIC_API_KEY` set, and whether the `model` option is honored.
+ *
+ * This is throwaway/diagnostic — it is NOT wired into the app. It exists only to
+ * de-risk the full implementation. Run with:
+ *   unset ANTHROPIC_API_KEY; bun run scripts/agent-sdk-auth-poc.ts [model]
+ *
+ * We deliberately pass NO tools and `tools: []` (all built-ins removed) so the
+ * model must answer from its own knowledge — the smallest possible round trip.
+ */
+import { query } from '@anthropic-ai/claude-agent-sdk';
+
+const model = process.argv[2] ?? 'claude-fable-5';
+
+// Fail loud if a paid metered credential is present — we want to prove the
+// OAuth/login path, not silently bill an API key.
+if (process.env.ANTHROPIC_API_KEY) {
+  console.error(
+    '[poc] ANTHROPIC_API_KEY is set in this shell. Unset it before running the PoC ' +
+      'so we exercise the Claude Code login path, not the metered API key.',
+  );
+  process.exit(2);
+}
+for (const meteredFlag of ['CLAUDE_CODE_USE_BEDROCK', 'CLAUDE_CODE_USE_VERTEX']) {
+  if (process.env[meteredFlag]) {
+    console.error(`[poc] ${meteredFlag} is set — refusing to run (would use a metered provider).`);
+    process.exit(2);
+  }
+}
+
+// Scope the env the SDK sees. We keep only what the SDK subprocess plausibly
+// needs plus the Claude Code OAuth context; we do NOT forward search/finance keys.
+const OAUTH_ENV_PREFIXES = ['CLAUDE_CODE_', 'CLAUDE_'];
+const BASE_ENV_KEYS = ['HOME', 'PATH', 'SHELL', 'USER', 'LOGNAME', 'TERM', 'LANG', 'TMPDIR', 'XDG_CONFIG_HOME'];
+const scopedEnv: Record<string, string | undefined> = {};
+for (const key of BASE_ENV_KEYS) {
+  if (process.env[key] !== undefined) scopedEnv[key] = process.env[key];
+}
+for (const [key, value] of Object.entries(process.env)) {
+  if (OAUTH_ENV_PREFIXES.some((p) => key.startsWith(p))) scopedEnv[key] = value;
+}
+
+async function main() {
+  console.log(`[poc] requesting model=${model} with NO ANTHROPIC_API_KEY, tools=[] ...`);
+
+  let sawInit = false;
+  let apiKeySource: string | undefined;
+  let reportedModel: string | undefined;
+  let finalText: string | undefined;
+  let resultSubtype: string | undefined;
+  let assistantError: string | undefined;
+  let costUsd: number | undefined;
+  const seenTypes = new Set<string>();
+
+  const q = query({
+    prompt: 'Reply with just the number. What is 1 + 1?',
+    options: {
+      model,
+      systemPrompt: 'You are a calculator. Answer with only the number, nothing else.',
+      settingSources: [],
+      tools: [],
+      maxTurns: 2,
+      permissionMode: 'default',
+      env: scopedEnv,
+    },
+  });
+
+  for await (const message of q) {
+    seenTypes.add(message.type);
+    if (message.type === 'system' && (message as { subtype?: string }).subtype === 'init') {
+      sawInit = true;
+      apiKeySource = (message as { apiKeySource?: string }).apiKeySource;
+      reportedModel = (message as { model?: string }).model;
+      console.log(`[poc] system/init: apiKeySource=${apiKeySource} model=${reportedModel}`);
+    } else if (message.type === 'assistant') {
+      const err = (message as { error?: string }).error;
+      if (err) assistantError = err;
+      const content = (message as { message?: { content?: unknown[] } }).message?.content ?? [];
+      for (const block of content as Array<{ type?: string; text?: string }>) {
+        if (block.type === 'text' && typeof block.text === 'string') {
+          finalText = (finalText ?? '') + block.text;
+        }
+      }
+    } else if (message.type === 'result') {
+      resultSubtype = (message as { subtype?: string }).subtype;
+      costUsd = (message as { total_cost_usd?: number }).total_cost_usd;
+      if (resultSubtype === 'success') {
+        finalText = (message as { result?: string }).result ?? finalText;
+      } else {
+        const errs = (message as { errors?: string[] }).errors ?? [];
+        console.error(`[poc] result error subtype=${resultSubtype}: ${errs.join('; ')}`);
+      }
+    }
+  }
+
+  console.log('\n===== PoC RESULT =====');
+  console.log('message types seen:', [...seenTypes].sort().join(', '));
+  console.log('saw system/init   :', sawInit);
+  console.log('apiKeySource      :', apiKeySource ?? '(none)');
+  console.log('model requested   :', model);
+  console.log('model reported    :', reportedModel ?? '(none)');
+  console.log('result subtype    :', resultSubtype ?? '(none)');
+  console.log('assistant error   :', assistantError ?? '(none)');
+  console.log('total_cost_usd    :', costUsd ?? '(none)');
+  console.log('final answer      :', JSON.stringify(finalText ?? '(none)'));
+
+  const ok = resultSubtype === 'success' && !!finalText && !assistantError;
+  console.log('PoC verdict       :', ok ? 'PASS' : 'FAIL');
+  process.exit(ok ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error('\n[poc] threw:', err instanceof Error ? (err.stack ?? err.message) : String(err));
+  process.exit(1);
+});

--- a/scripts/agent-sdk-plumbing-poc.ts
+++ b/scripts/agent-sdk-plumbing-poc.ts
@@ -1,0 +1,113 @@
+/**
+ * Phase 2 plumbing PoC: prove the full SDK → in-process MCP tool → result →
+ * answer path, and that built-in tools are denied, WITHOUT any external network
+ * dependency. Uses a deterministic local tool through the exact same SDK options
+ * the AgentSdkAgent uses (tools: [], disallowedTools, allowedTools, canUseTool,
+ * scoped env). This validates acceptance #1's mechanism and #6 independently of
+ * EDINET DB endpoint availability.
+ *
+ *   unset ANTHROPIC_API_KEY; bun run scripts/agent-sdk-plumbing-poc.ts [model]
+ */
+import { query, tool, createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
+import { z } from 'zod';
+import { buildSdkEnv } from '../src/agent/sdk-env-guard.js';
+
+const model = process.argv[2] ?? 'claude-sonnet-5';
+
+if (process.env.ANTHROPIC_API_KEY) {
+  console.error('[poc] refusing to run with ANTHROPIC_API_KEY set.');
+  process.exit(2);
+}
+
+let toolWasCalled = false;
+
+const getSecretNumber = tool(
+  'get_secret_number',
+  'Returns the secret number for a given company id. The only way to learn the secret number.',
+  { company_id: z.string().describe('The company id to look up') },
+  async (args) => {
+    toolWasCalled = true;
+    // Deterministic, no network.
+    const n = args.company_id === 'ACME' ? 4242 : 1;
+    return { content: [{ type: 'text' as const, text: JSON.stringify({ company_id: args.company_id, secret_number: n }) }] };
+  },
+  { annotations: { readOnlyHint: true } },
+);
+
+const server = createSdkMcpServer({ name: 'dexter', version: '1.0.0', tools: [getSecretNumber] });
+
+async function main() {
+  let sawInit = false;
+  let apiKeySource: string | undefined;
+  let initTools: string[] = [];
+  let finalText = '';
+  let resultSubtype: string | undefined;
+  const builtinsAttempted: string[] = [];
+  const toolUses: string[] = [];
+
+  for await (const message of query({
+    prompt:
+      'Use the get_secret_number tool to look up the secret number for company id "ACME", then reply with just that number.',
+    options: {
+      model,
+      systemPrompt: 'You are a lookup assistant. Use tools to find values; never guess.',
+      settingSources: [],
+      tools: [],
+      disallowedTools: ['Bash', 'Read', 'Write', 'Edit', 'WebSearch', 'WebFetch', 'Task', 'TodoWrite'],
+      allowedTools: ['mcp__dexter__*'],
+      mcpServers: { dexter: server },
+      strictMcpConfig: true,
+      permissionMode: 'default',
+      maxTurns: 6,
+      env: buildSdkEnv(),
+      canUseTool: async (toolName: string, input: Record<string, unknown>) => {
+        if (toolName.startsWith('mcp__dexter__')) {
+          return { behavior: 'allow' as const, updatedInput: input };
+        }
+        builtinsAttempted.push(toolName);
+        return { behavior: 'deny' as const, message: 'not allowed in SDK mode' };
+      },
+    },
+  })) {
+    if (message.type === 'system' && (message as { subtype?: string }).subtype === 'init') {
+      sawInit = true;
+      apiKeySource = (message as { apiKeySource?: string }).apiKeySource;
+      initTools = (message as { tools?: string[] }).tools ?? [];
+    } else if (message.type === 'assistant') {
+      const content = (message as { message?: { content?: unknown[] } }).message?.content ?? [];
+      for (const b of content as Array<{ type?: string; name?: string; text?: string }>) {
+        if (b.type === 'tool_use' && b.name) toolUses.push(b.name);
+      }
+    } else if (message.type === 'result') {
+      resultSubtype = (message as { subtype?: string }).subtype;
+      if (resultSubtype === 'success') finalText = (message as { result?: string }).result ?? '';
+    }
+  }
+
+  console.log('\n===== PLUMBING POC RESULT =====');
+  console.log('saw system/init      :', sawInit);
+  console.log('apiKeySource         :', apiKeySource ?? '(none)');
+  const builtinsInContext = initTools.filter((t) => !t.startsWith('mcp__'));
+  console.log('init tools           :', initTools.join(', ') || '(none)');
+  console.log('builtins in context  :', builtinsInContext.join(', ') || '(none ✓)');
+  console.log('tool_use blocks      :', toolUses.join(', ') || '(none)');
+  console.log('dexter tool ran      :', toolWasCalled);
+  console.log('builtins attempted   :', builtinsAttempted.join(', ') || '(none ✓)');
+  console.log('result subtype       :', resultSubtype ?? '(none)');
+  console.log('final answer         :', JSON.stringify(finalText));
+
+  const answeredWith4242 = finalText.includes('4242');
+  const ok =
+    resultSubtype === 'success' &&
+    toolWasCalled &&
+    answeredWith4242 &&
+    builtinsAttempted.length === 0 &&
+    builtinsInContext.length === 0;
+  console.log('verdict              :', ok ? 'PASS' : 'FAIL');
+  process.exit(ok ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error('[poc] threw:', err instanceof Error ? (err.stack ?? err.message) : String(err));
+  process.exit(1);
+});

--- a/scripts/agent-sdk-tool-poc.ts
+++ b/scripts/agent-sdk-tool-poc.ts
@@ -1,0 +1,66 @@
+/**
+ * Phase 2 acceptance harness: run the real AgentSdkAgent against a live query
+ * that should trigger a Dexter EDINET DB tool call, with NO ANTHROPIC_API_KEY.
+ *
+ * Proves acceptance criteria #1 (real task completes on login creds), #6 (no SDK
+ * built-in tools invoked). Prints the AgentEvent stream and the tools observed.
+ *
+ *   unset ANTHROPIC_API_KEY; EDINETDB_API_KEY=... bun run scripts/agent-sdk-tool-poc.ts
+ */
+import { AgentSdkAgent } from '../src/agent/agent-sdk-agent.js';
+import type { AgentEvent } from '../src/agent/types.js';
+
+const model = process.argv[2] ?? 'claude-sonnet-5';
+const userQuery =
+  process.argv.slice(3).join(' ') ||
+  'What industry is Toyota (7203) in? Use get_company_info and state the industry.';
+
+if (process.env.ANTHROPIC_API_KEY) {
+  console.error('[poc] refusing to run with ANTHROPIC_API_KEY set (would use metered path).');
+  process.exit(2);
+}
+
+async function main() {
+  const agent = await AgentSdkAgent.create({ model, channel: 'cli' });
+
+  const events: AgentEvent[] = [];
+  let answer = '';
+  const toolStarts: string[] = [];
+
+  for await (const ev of agent.run(userQuery)) {
+    events.push(ev);
+    if (ev.type === 'tool_start') {
+      toolStarts.push(ev.tool);
+      console.log(`  [tool_start] ${ev.tool} ${JSON.stringify(ev.args)}`);
+    } else if (ev.type === 'tool_end') {
+      const preview = ev.result.slice(0, 120).replace(/\s+/g, ' ');
+      console.log(`  [tool_end]   ${ev.tool} (${ev.duration ?? '?'}ms): ${preview}…`);
+    } else if (ev.type === 'thinking') {
+      console.log(`  [thinking]   ${ev.message.slice(0, 200)}`);
+    } else if (ev.type === 'done') {
+      answer = ev.answer;
+    }
+  }
+
+  const observed = agent.observedToolNames;
+  const builtinsCalled = observed.filter(
+    (n) => !n.startsWith('mcp__dexter__') && n !== 'AskUserQuestion',
+  );
+
+  console.log('\n===== TOOL POC RESULT =====');
+  console.log('event types      :', [...new Set(events.map((e) => e.type))].sort().join(', '));
+  console.log('tool_starts      :', toolStarts.join(', ') || '(none)');
+  console.log('tools observed   :', observed.join(', ') || '(none)');
+  console.log('builtins invoked :', builtinsCalled.join(', ') || '(none)  ✓');
+  console.log('final answer     :', JSON.stringify(answer.slice(0, 400)));
+
+  const spinnerClosed = events.some((e) => e.type === 'done');
+  const ok = spinnerClosed && !!answer && builtinsCalled.length === 0;
+  console.log('verdict          :', ok ? 'PASS' : 'CHECK');
+  process.exit(ok ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error('[poc] threw:', err instanceof Error ? (err.stack ?? err.message) : String(err));
+  process.exit(1);
+});

--- a/src/agent/agent-sdk-agent.ts
+++ b/src/agent/agent-sdk-agent.ts
@@ -1,0 +1,245 @@
+/**
+ * Claude Agent SDK mode agent.
+ *
+ * Presents the SAME `run(query): AsyncGenerator<AgentEvent>` interface as the
+ * LangChain-based `Agent`, but delegates the entire loop to the Agent SDK's
+ * `query()`. Dexter's ink UI and AgentRunnerController consume the yielded
+ * AgentEvents without modification.
+ *
+ * Responsibilities:
+ *   - Register Dexter's raw tools as an in-process MCP server (no internal LLM).
+ *   - Deny all SDK built-in tools; allow only Dexter MCP tools + AskUserQuestion.
+ *   - Hand the SDK an allowlisted env (never process.env whole) and fail loud on
+ *     unexpected/ambiguous billing paths.
+ *   - Convert the full SDKMessage union to AgentEvents via a pure, exhaustively-
+ *     tested translator; unknown variants degrade to a diagnostic line and never
+ *     wedge the UI spinner.
+ */
+import { query } from '@anthropic-ai/claude-agent-sdk';
+import type { Options, PermissionResult, ElicitationRequest } from '@anthropic-ai/claude-agent-sdk';
+import type { AgentEvent, DoneEvent, TokenUsage } from './types.js';
+import { buildDexterMcpServer, DEXTER_MCP_SERVER_NAME } from './sdk-tool-adapter.js';
+import { buildSdkAgentSystemPrompt } from './sdk-prompt.js';
+import { buildSdkEnv, evaluateEnvGuard } from './sdk-env-guard.js';
+import { translateSdkMessage, type TranslateContext } from './sdk-message-translate.js';
+
+/** SDK built-in tools we explicitly deny (belt-and-suspenders; `tools: []` also removes them). */
+export const SDK_BUILTIN_TOOLS_TO_DENY = [
+  'Bash',
+  'Read',
+  'Write',
+  'Edit',
+  'MultiEdit',
+  'NotebookEdit',
+  'Glob',
+  'Grep',
+  'WebSearch',
+  'WebFetch',
+  'Task',
+  'TodoWrite',
+  'Skill',
+  'KillShell',
+  'BashOutput',
+  'SlashCommand',
+] as const;
+
+/** The one SDK-native tool we DO allow: the model's ask-user question mechanism. */
+export const ASK_USER_QUESTION_TOOL = 'AskUserQuestion';
+
+const DEFAULT_MAX_TURNS = 40;
+
+export interface AgentSdkAgentConfig {
+  /** Model id (e.g. 'claude-fable-5'). */
+  model: string;
+  /** Abort signal for cancellation. */
+  signal?: AbortSignal;
+  /** Delivery channel (affects the system prompt tone; defaults to 'cli'). */
+  channel?: string;
+  /** Max agentic turns before the SDK stops. */
+  maxTurns?: number;
+  /** Client-side USD budget ceiling; SDK stops when its estimate reaches it. */
+  maxBudgetUsd?: number;
+  /** User has explicitly opted into a usage-based (metered) credential path. */
+  allowMetered?: boolean;
+  /**
+   * Bridge for user questions surfaced by the SDK (MCP elicitation). Returns the
+   * user's free-text answer, or null if cancelled. When omitted, questions are
+   * auto-declined so the run does not hang.
+   */
+  requestUserInput?: (prompt: string) => Promise<string | null>;
+}
+
+export class AgentSdkAgent {
+  private readonly config: AgentSdkAgentConfig;
+  private readonly systemPrompt: string;
+  private readonly mcp = buildDexterMcpServer();
+  /** Tool names actually reported by the SDK as used, for the "no built-ins" check. */
+  private readonly toolsSeen = new Set<string>();
+
+  private constructor(config: AgentSdkAgentConfig, systemPrompt: string) {
+    this.config = config;
+    this.systemPrompt = systemPrompt;
+  }
+
+  static async create(config: AgentSdkAgentConfig): Promise<AgentSdkAgent> {
+    const systemPrompt = await buildSdkAgentSystemPrompt(config.model, config.channel);
+    return new AgentSdkAgent(config, systemPrompt);
+  }
+
+  /** Fully-qualified Dexter tool names + AskUserQuestion, for `allowedTools`. */
+  private allowedTools(): string[] {
+    return [`mcp__${DEXTER_MCP_SERVER_NAME}__*`, ASK_USER_QUESTION_TOOL];
+  }
+
+  /**
+   * Permission handler: allow Dexter MCP tools + AskUserQuestion, deny everything
+   * else (fail-safe). Invoked only when the permission flow falls through to a
+   * prompt; `allowedTools` auto-approves the Dexter tools, so in practice this
+   * blocks any built-in the model somehow attempts.
+   */
+  private canUseTool = async (
+    toolName: string,
+    input: Record<string, unknown>,
+  ): Promise<PermissionResult> => {
+    const isDexterTool = toolName.startsWith(`mcp__${DEXTER_MCP_SERVER_NAME}__`);
+    const isAskUser = toolName === ASK_USER_QUESTION_TOOL;
+    if (isDexterTool || isAskUser) {
+      return { behavior: 'allow', updatedInput: input };
+    }
+    return {
+      behavior: 'deny',
+      message: `Tool '${toolName}' is not available in Claude Agent SDK mode (only Dexter data tools are permitted).`,
+    };
+  };
+
+  /** MCP elicitation → user input bridge. */
+  private onElicitation = async (
+    request: ElicitationRequest,
+  ): Promise<{ action: 'accept' | 'decline' | 'cancel'; content?: Record<string, string | number | boolean | string[]> }> => {
+    const message = (request as { message?: string }).message ?? 'The assistant is requesting input.';
+    if (!this.config.requestUserInput) {
+      return { action: 'decline' };
+    }
+    const answer = await this.config.requestUserInput(message);
+    if (answer === null) return { action: 'cancel' };
+    return { action: 'accept', content: { response: answer } };
+  };
+
+  private buildOptions(): Options {
+    return {
+      model: this.config.model,
+      systemPrompt: this.systemPrompt,
+      // Do not read user/project/local .claude settings or CLAUDE.md.
+      settingSources: [],
+      // Remove ALL built-in tools from context (availability layer).
+      tools: [],
+      // Belt-and-suspenders deny (permission + availability layer).
+      disallowedTools: [...SDK_BUILTIN_TOOLS_TO_DENY],
+      // Auto-approve only Dexter tools + AskUserQuestion.
+      allowedTools: this.allowedTools(),
+      // Register the raw Dexter tools; use only these MCP servers.
+      mcpServers: { [DEXTER_MCP_SERVER_NAME]: this.mcp.server },
+      strictMcpConfig: true,
+      // Fail-safe permission handler for anything that falls through.
+      canUseTool: this.canUseTool,
+      permissionMode: 'default',
+      maxTurns: this.config.maxTurns ?? DEFAULT_MAX_TURNS,
+      ...(this.config.maxBudgetUsd !== undefined ? { maxBudgetUsd: this.config.maxBudgetUsd } : {}),
+      onElicitation: this.onElicitation,
+      abortController: this.toAbortController(),
+      // Allowlisted env — never forward process.env whole.
+      env: buildSdkEnv({ allowMetered: this.config.allowMetered }),
+    };
+  }
+
+  /** The SDK wants an AbortController; adapt an incoming AbortSignal to one. */
+  private toAbortController(): AbortController | undefined {
+    const signal = this.config.signal;
+    if (!signal) return undefined;
+    const controller = new AbortController();
+    if (signal.aborted) controller.abort();
+    else signal.addEventListener('abort', () => controller.abort(), { once: true });
+    return controller;
+  }
+
+  /**
+   * Run the agent, yielding Dexter AgentEvents. Mirrors `Agent.run()`.
+   */
+  async *run(userQuery: string): AsyncGenerator<AgentEvent> {
+    const startTime = Date.now();
+
+    // Billing-path guard (fail-loud). Surface the resolved auth route, and stop
+    // before running if a usage-based/ambiguous path is present and the user has
+    // not opted in. The SDK itself manages credentials; this only prevents an
+    // unintended metered run.
+    const guard = evaluateEnvGuard({ allowMetered: this.config.allowMetered });
+    yield { type: 'thinking', message: guard.summary };
+    if (guard.requiresConfirmation) {
+      const instructions = this.config.allowMetered
+        ? guard.detail ?? guard.summary
+        : `${guard.detail ?? guard.summary}\n\nTo proceed on this path, set DEXTER_AGENT_SDK_ALLOW_METERED=1 and retry.`;
+      yield this.doneEvent(
+        `Claude Agent SDK mode halted before running to avoid an unintended billing path.\n\n${instructions}`,
+        startTime,
+        undefined,
+      );
+      return;
+    }
+
+    let finalAnswer = '';
+    let terminalSeen = false;
+    let lastUsage: TokenUsage | undefined;
+
+    const translateCtx: TranslateContext = {
+      model: this.config.model,
+      maxTurns: this.config.maxTurns ?? DEFAULT_MAX_TURNS,
+      onToolSeen: (name) => this.toolsSeen.add(name),
+      onFinalAnswer: (t) => { finalAnswer = t; },
+      onUsage: (u) => { lastUsage = u; },
+      onTerminal: () => { terminalSeen = true; },
+    };
+
+    try {
+      for await (const message of query({ prompt: userQuery, options: this.buildOptions() })) {
+        for (const event of translateSdkMessage(message, translateCtx)) {
+          yield event;
+        }
+        // A `result` frame is terminal — emit the Dexter `done` right after so the
+        // spinner closes exactly once, carrying the captured answer + usage.
+        if (terminalSeen) {
+          yield this.doneEvent(finalAnswer, startTime, lastUsage);
+          return;
+        }
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (error instanceof Error && (error.name === 'AbortError' || /abort/i.test(message))) {
+        // Interrupted — emit a terminal done so the spinner closes.
+        yield this.doneEvent(finalAnswer, startTime, lastUsage);
+        return;
+      }
+      // Any other throw (incl. auth/spawn failures) → terminal error done.
+      yield this.doneEvent(`Error: ${message}`, startTime, lastUsage);
+      return;
+    }
+
+    // Stream ended without a terminal result — still close the turn.
+    yield this.doneEvent(finalAnswer, startTime, lastUsage);
+  }
+
+  /** Names of tools the SDK actually reported using (for the built-in-tools check). */
+  get observedToolNames(): string[] {
+    return [...this.toolsSeen];
+  }
+
+  private doneEvent(answer: string, startTime: number, usage: TokenUsage | undefined): DoneEvent {
+    return {
+      type: 'done',
+      answer,
+      toolCalls: [],
+      iterations: 0,
+      totalTime: Date.now() - startTime,
+      tokenUsage: usage,
+    };
+  }
+}

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -25,6 +25,9 @@ const DEFAULT_MAX_ITERATIONS = 10;
 const MAX_OVERFLOW_RETRIES = 2;
 const OVERFLOW_KEEP_ROUNDS = 3;
 
+/** Tools that require an interactive user and are only bound on the CLI channel. */
+const CLI_ONLY_TOOLS = new Set<string>(['ask_user_question']);
+
 /**
  * The core agent class that handles the agent loop and tool execution.
  *
@@ -62,6 +65,8 @@ export class Agent {
       config.signal,
       config.requestToolApproval,
       config.sessionApprovedTools,
+      undefined,
+      config.requestUserInput,
     );
     this.systemPrompt = systemPrompt;
     this.signal = config.signal;
@@ -72,9 +77,15 @@ export class Agent {
   static async create(config: AgentConfig = {}): Promise<Agent> {
     const model = config.model ?? DEFAULT_MODEL;
     const allTools = getTools(model);
-    const tools = config.toolAllowlist
+    let tools = config.toolAllowlist
       ? allTools.filter(t => config.toolAllowlist!.includes(t.name))
       : allTools;
+    // CLI-only tools (interactive prompts) are dropped on non-CLI channels
+    // (WhatsApp/gateway) and in headless runs, where there is no user at a keyboard.
+    const isCli = !config.channel || config.channel === 'cli';
+    if (!isCli) {
+      tools = tools.filter(t => !CLI_ONLY_TOOLS.has(t.name));
+    }
     // The concurrency map is a name→bool lookup; extra entries are harmless since
     // toolMap only holds the (possibly filtered) tools above.
     const concurrencyMap = getToolConcurrencyMap(model);

--- a/src/agent/sdk-env-guard.test.ts
+++ b/src/agent/sdk-env-guard.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  detectAuthRoutes,
+  evaluateEnvGuard,
+  buildSdkEnv,
+  METERED_ROUTES,
+} from './sdk-env-guard.js';
+
+/** Build a minimal fake env; every field optional. */
+function env(overrides: Record<string, string | undefined> = {}): NodeJS.ProcessEnv {
+  return { HOME: '/home/x', PATH: '/usr/bin', ...overrides } as NodeJS.ProcessEnv;
+}
+
+describe('detectAuthRoutes', () => {
+  test('classifies bare environment as Claude Code login (non-metered)', () => {
+    const routes = detectAuthRoutes(env());
+    expect(routes).toHaveLength(1);
+    expect(routes[0].route).toBe('claude-code-login');
+    expect(routes[0].metered).toBe(false);
+  });
+
+  test('classifies ANTHROPIC_API_KEY as metered api-key', () => {
+    const routes = detectAuthRoutes(env({ ANTHROPIC_API_KEY: 'sk-abc' }));
+    const apiKey = routes.find((r) => r.route === 'api-key');
+    expect(apiKey).toBeDefined();
+    expect(apiKey?.metered).toBe(true);
+  });
+
+  test('classifies OAuth token as non-metered', () => {
+    const routes = detectAuthRoutes(env({ CLAUDE_CODE_OAUTH_TOKEN: 'oauth-tok' }));
+    const oauth = routes.find((r) => r.route === 'oauth-token');
+    expect(oauth).toBeDefined();
+    expect(oauth?.metered).toBe(false);
+  });
+
+  test.each([
+    ['CLAUDE_CODE_USE_BEDROCK', 'bedrock'],
+    ['CLAUDE_CODE_USE_VERTEX', 'vertex'],
+    ['CLAUDE_CODE_USE_FOUNDRY', 'foundry'],
+    ['CLAUDE_CODE_USE_ANTHROPIC_AWS', 'anthropic-aws'],
+  ])('classifies %s=1 as metered %s', (flag, route) => {
+    const routes = detectAuthRoutes(env({ [flag]: '1' }));
+    const hit = routes.find((r) => r.route === route);
+    expect(hit).toBeDefined();
+    expect(hit?.metered).toBe(true);
+    expect(METERED_ROUTES as readonly string[]).toContain(route);
+  });
+
+  test('treats flag=0/false/empty as disabled', () => {
+    for (const val of ['0', 'false', '', 'no']) {
+      const routes = detectAuthRoutes(env({ CLAUDE_CODE_USE_BEDROCK: val }));
+      expect(routes.some((r) => r.route === 'bedrock')).toBe(false);
+    }
+  });
+});
+
+describe('evaluateEnvGuard', () => {
+  test('login-only env requires no confirmation', () => {
+    const r = evaluateEnvGuard({ env: env() });
+    expect(r.hasMetered).toBe(false);
+    expect(r.requiresConfirmation).toBe(false);
+  });
+
+  test('api-key present requires confirmation unless opted in', () => {
+    const withKey = env({ ANTHROPIC_API_KEY: 'sk-abc' });
+    expect(evaluateEnvGuard({ env: withKey }).requiresConfirmation).toBe(true);
+    expect(evaluateEnvGuard({ env: withKey, allowMetered: true }).requiresConfirmation).toBe(false);
+  });
+
+  test('conflict (api-key + oauth token) requires confirmation even when opted in', () => {
+    const conflicting = env({ ANTHROPIC_API_KEY: 'sk-abc', CLAUDE_CODE_OAUTH_TOKEN: 'tok' });
+    const r = evaluateEnvGuard({ env: conflicting, allowMetered: true });
+    expect(r.hasConflict).toBe(true);
+    expect(r.requiresConfirmation).toBe(true);
+    expect(r.detail).toBeDefined();
+  });
+
+  test('two metered providers at once is a conflict', () => {
+    const two = env({ CLAUDE_CODE_USE_BEDROCK: '1', CLAUDE_CODE_USE_VERTEX: '1' });
+    expect(evaluateEnvGuard({ env: two, allowMetered: true }).hasConflict).toBe(true);
+  });
+
+  test('summary is always populated', () => {
+    expect(evaluateEnvGuard({ env: env() }).summary).toContain('Claude Code login');
+  });
+});
+
+describe('buildSdkEnv', () => {
+  test('forwards OS baseline + Claude Code OAuth context', () => {
+    const out = buildSdkEnv({
+      env: env({ CLAUDE_CODE_OAUTH_TOKEN: 'tok', CLAUDE_CODE_ENTRYPOINT: 'cli' }),
+    });
+    expect(out.HOME).toBe('/home/x');
+    expect(out.PATH).toBe('/usr/bin');
+    expect(out.CLAUDE_CODE_OAUTH_TOKEN).toBe('tok');
+    expect(out.CLAUDE_CODE_ENTRYPOINT).toBe('cli');
+  });
+
+  test('strips metered vars when not opted in', () => {
+    const out = buildSdkEnv({
+      env: env({
+        ANTHROPIC_API_KEY: 'sk-abc',
+        CLAUDE_CODE_USE_BEDROCK: '1',
+        AWS_ACCESS_KEY_ID: 'AKIA',
+      }),
+      allowMetered: false,
+    });
+    expect(out.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(out.CLAUDE_CODE_USE_BEDROCK).toBeUndefined();
+    expect(out.AWS_ACCESS_KEY_ID).toBeUndefined();
+  });
+
+  test('forwards metered vars when opted in', () => {
+    const out = buildSdkEnv({
+      env: env({ ANTHROPIC_API_KEY: 'sk-abc' }),
+      allowMetered: true,
+    });
+    expect(out.ANTHROPIC_API_KEY).toBe('sk-abc');
+  });
+
+  test('does not forward unrelated secrets (search/finance keys)', () => {
+    const out = buildSdkEnv({
+      env: env({ EDINETDB_API_KEY: 'edb', OPENAI_API_KEY: 'oai', TAVILY_API_KEY: 'tav' }),
+    });
+    expect(out.EDINETDB_API_KEY).toBeUndefined();
+    expect(out.OPENAI_API_KEY).toBeUndefined();
+    expect(out.TAVILY_API_KEY).toBeUndefined();
+  });
+});

--- a/src/agent/sdk-env-guard.ts
+++ b/src/agent/sdk-env-guard.ts
@@ -1,0 +1,277 @@
+/**
+ * Environment + auth guard for the Claude Agent SDK mode.
+ *
+ * The Agent SDK resolves its own credentials (Claude Code login / OAuth token /
+ * ANTHROPIC_API_KEY / Bedrock / Vertex / Foundry). Dexter does NOT implement any
+ * auth flow. This module's job is narrow and defensive:
+ *
+ *   1. Classify which credential path the SDK will most likely take, from env.
+ *   2. Build an allowlisted env object to hand the SDK (never `process.env` whole),
+ *      so we don't silently forward a metered provider path we didn't intend.
+ *   3. Fail loud when a metered path is present but the user hasn't opted into it,
+ *      or when signals conflict (e.g. an API key AND a Bedrock flag).
+ *
+ * "Fail loud" here means: return a guard result the caller surfaces to the user
+ * and blocks on, rather than quietly running on an unexpected billing path.
+ */
+
+/** How the SDK will most likely authenticate, inferred from the environment. */
+export type AuthRoute =
+  | 'claude-code-login' // no explicit key/flags → SDK uses local Claude Code login / OAuth
+  | 'oauth-token' // CLAUDE_CODE_OAUTH_TOKEN present
+  | 'api-key' // ANTHROPIC_API_KEY present (metered)
+  | 'bedrock' // CLAUDE_CODE_USE_BEDROCK (metered via AWS)
+  | 'vertex' // CLAUDE_CODE_USE_VERTEX (metered via GCP)
+  | 'foundry' // CLAUDE_CODE_USE_FOUNDRY (metered)
+  | 'anthropic-aws'; // CLAUDE_CODE_USE_ANTHROPIC_AWS (metered)
+
+/** Credential paths that incur usage-based billing rather than subscription/login. */
+export const METERED_ROUTES: readonly AuthRoute[] = [
+  'api-key',
+  'bedrock',
+  'vertex',
+  'foundry',
+  'anthropic-aws',
+] as const;
+
+export interface DetectedRoute {
+  route: AuthRoute;
+  /** The env var (or absence) that triggered this classification. */
+  signal: string;
+  metered: boolean;
+  /** Human-readable label for display. */
+  label: string;
+}
+
+const ROUTE_LABELS: Record<AuthRoute, string> = {
+  'claude-code-login': 'Claude Code login',
+  'oauth-token': 'OAuth token (CLAUDE_CODE_OAUTH_TOKEN)',
+  'api-key': 'API key (ANTHROPIC_API_KEY) — usage-based billing',
+  bedrock: 'Amazon Bedrock — usage-based billing',
+  vertex: 'Google Vertex AI — usage-based billing',
+  foundry: 'Azure AI Foundry — usage-based billing',
+  'anthropic-aws': 'Anthropic on AWS — usage-based billing',
+};
+
+/**
+ * Provider-selecting env flags. Presence (truthy, not '0'/'false') means the SDK
+ * routes to that provider.
+ */
+const PROVIDER_FLAGS: Array<{ envVar: string; route: AuthRoute }> = [
+  { envVar: 'CLAUDE_CODE_USE_BEDROCK', route: 'bedrock' },
+  { envVar: 'CLAUDE_CODE_USE_VERTEX', route: 'vertex' },
+  { envVar: 'CLAUDE_CODE_USE_FOUNDRY', route: 'foundry' },
+  { envVar: 'CLAUDE_CODE_USE_ANTHROPIC_AWS', route: 'anthropic-aws' },
+];
+
+function isFlagEnabled(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  const v = value.trim().toLowerCase();
+  return v !== '' && v !== '0' && v !== 'false' && v !== 'no';
+}
+
+/**
+ * Detect every credential signal present in `env`. Order does not imply the SDK's
+ * internal precedence; we report all of them so conflicts can be flagged.
+ */
+export function detectAuthRoutes(env: NodeJS.ProcessEnv = process.env): DetectedRoute[] {
+  const routes: DetectedRoute[] = [];
+
+  for (const { envVar, route } of PROVIDER_FLAGS) {
+    if (isFlagEnabled(env[envVar])) {
+      routes.push({ route, signal: envVar, metered: true, label: ROUTE_LABELS[route] });
+    }
+  }
+
+  if (env.ANTHROPIC_API_KEY && env.ANTHROPIC_API_KEY.trim() !== '') {
+    routes.push({ route: 'api-key', signal: 'ANTHROPIC_API_KEY', metered: true, label: ROUTE_LABELS['api-key'] });
+  }
+
+  if (env.CLAUDE_CODE_OAUTH_TOKEN && env.CLAUDE_CODE_OAUTH_TOKEN.trim() !== '') {
+    routes.push({
+      route: 'oauth-token',
+      signal: 'CLAUDE_CODE_OAUTH_TOKEN',
+      metered: false,
+      label: ROUTE_LABELS['oauth-token'],
+    });
+  }
+
+  // If nothing explicit is set, the SDK falls back to the local Claude Code login.
+  if (routes.length === 0) {
+    routes.push({
+      route: 'claude-code-login',
+      signal: '(no credential env vars set)',
+      metered: false,
+      label: ROUTE_LABELS['claude-code-login'],
+    });
+  }
+
+  return routes;
+}
+
+export interface EnvGuardResult {
+  /** Every credential signal detected in the source env. */
+  detected: DetectedRoute[];
+  /** True when at least one usage-based path is present. */
+  hasMetered: boolean;
+  /** True when both a metered and a login/OAuth path are present (ambiguous billing). */
+  hasConflict: boolean;
+  /**
+   * When true, the caller must stop and confirm with the user before running
+   * (a metered path is present, or signals conflict). Cleared by opting in.
+   */
+  requiresConfirmation: boolean;
+  /** One-line human summary for display. */
+  summary: string;
+  /** Longer, multi-line explanation for the confirm prompt (present when requiresConfirmation). */
+  detail?: string;
+}
+
+/**
+ * Evaluate the env for billing-path safety.
+ *
+ * @param opts.env            Source environment (defaults to process.env).
+ * @param opts.allowMetered   User has explicitly opted into a usage-based path
+ *                            (e.g. chose to use their API key). When true, a
+ *                            metered path alone does not require confirmation,
+ *                            but a *conflict* still does.
+ */
+export function evaluateEnvGuard(opts: { env?: NodeJS.ProcessEnv; allowMetered?: boolean } = {}): EnvGuardResult {
+  const env = opts.env ?? process.env;
+  const allowMetered = opts.allowMetered ?? false;
+  const detected = detectAuthRoutes(env);
+
+  const meteredRoutes = detected.filter((d) => d.metered);
+  const nonMeteredRoutes = detected.filter((d) => !d.metered);
+  const hasMetered = meteredRoutes.length > 0;
+  // A conflict is a metered path co-existing with an explicit login/OAuth path,
+  // OR two different metered providers set at once.
+  const hasExplicitLogin = nonMeteredRoutes.some((d) => d.route === 'oauth-token');
+  const hasConflict =
+    (hasMetered && hasExplicitLogin) || new Set(meteredRoutes.map((d) => d.route)).size > 1;
+
+  const requiresConfirmation = hasConflict || (hasMetered && !allowMetered);
+
+  const summary =
+    detected.length === 1
+      ? `Auth route: ${detected[0].label}`
+      : `Auth routes detected: ${detected.map((d) => d.label).join('; ')}`;
+
+  let detail: string | undefined;
+  if (requiresConfirmation) {
+    const lines: string[] = [];
+    if (hasConflict) {
+      lines.push(
+        'Conflicting credential signals are present. The SDK may run on an unexpected billing path:',
+      );
+    } else {
+      lines.push('A usage-based (billable) credential path is present in your environment:');
+    }
+    for (const d of detected) {
+      lines.push(`  - ${d.signal}: ${d.label}${d.metered ? '  [BILLABLE]' : ''}`);
+    }
+    lines.push('');
+    lines.push(
+      'Claude Agent SDK mode does not manage credentials — the SDK will use whatever it resolves.',
+    );
+    lines.push(
+      'If you intend to use a usage-based path, confirm to proceed. Otherwise unset the variable(s) above',
+    );
+    lines.push('to run on your Claude Code login, then try again.');
+    detail = lines.join('\n');
+  }
+
+  return { detected, hasMetered, hasConflict, requiresConfirmation, summary, detail };
+}
+
+/**
+ * Env var name prefixes that carry the Claude Code / SDK login + OAuth context.
+ * These must reach the SDK subprocess for the login path to work.
+ */
+const OAUTH_ENV_PREFIXES = ['CLAUDE_CODE_', 'CLAUDE_', 'ANTHROPIC_'] as const;
+
+/**
+ * Baseline OS env keys the SDK subprocess needs to spawn/run. We forward these
+ * unconditionally (they are not credentials).
+ */
+const BASE_ENV_KEYS = [
+  'HOME',
+  'PATH',
+  'SHELL',
+  'USER',
+  'LOGNAME',
+  'TERM',
+  'LANG',
+  'LC_ALL',
+  'TMPDIR',
+  'TEMP',
+  'TMP',
+  'XDG_CONFIG_HOME',
+  'XDG_CACHE_HOME',
+  'XDG_DATA_HOME',
+  'APPDATA',
+  'LOCALAPPDATA',
+  'SystemRoot',
+  'PROGRAMFILES',
+  'PROGRAMDATA',
+  'NODE_OPTIONS',
+  'https_proxy',
+  'http_proxy',
+  'no_proxy',
+  'HTTPS_PROXY',
+  'HTTP_PROXY',
+  'NO_PROXY',
+] as const;
+
+/**
+ * Build the allowlisted env to hand the SDK. This REPLACES process.env for the
+ * SDK subprocess (the SDK's `env` option does not merge), so we must include the
+ * OS baseline plus the credential/OAuth context. Provider metered flags are
+ * forwarded ONLY when the user opted in — otherwise they are stripped so an
+ * unintended billable path cannot activate.
+ *
+ * @param opts.allowMetered  When true, metered provider flags/keys are forwarded
+ *                          as-is (user chose a usage-based path). When false,
+ *                          they are omitted from the SDK env.
+ */
+export function buildSdkEnv(opts: { env?: NodeJS.ProcessEnv; allowMetered?: boolean } = {}): Record<string, string | undefined> {
+  const source = opts.env ?? process.env;
+  const allowMetered = opts.allowMetered ?? false;
+
+  const meteredEnvVars = new Set<string>([
+    'ANTHROPIC_API_KEY',
+    'ANTHROPIC_AUTH_TOKEN',
+    ...PROVIDER_FLAGS.map((f) => f.envVar),
+    // AWS/GCP credential material only matters when a provider flag is on; strip
+    // when not opted in so we never half-configure a metered path.
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_SESSION_TOKEN',
+    'AWS_REGION',
+    'AWS_PROFILE',
+    'GOOGLE_APPLICATION_CREDENTIALS',
+    'ANTHROPIC_VERTEX_PROJECT_ID',
+    'CLOUD_ML_REGION',
+  ]);
+
+  const out: Record<string, string | undefined> = {};
+
+  for (const key of BASE_ENV_KEYS) {
+    if (source[key] !== undefined) out[key] = source[key];
+  }
+
+  for (const [key, value] of Object.entries(source)) {
+    const isOauthContext = OAUTH_ENV_PREFIXES.some((p) => key.startsWith(p));
+    if (!isOauthContext) continue;
+    if (meteredEnvVars.has(key) && !allowMetered) continue; // strip metered unless opted in
+    out[key] = value;
+  }
+
+  // Belt-and-suspenders: when not opted into metering, ensure no metered var slips
+  // through under a prefix we didn't special-case.
+  if (!allowMetered) {
+    for (const key of meteredEnvVars) delete out[key];
+  }
+
+  return out;
+}

--- a/src/agent/sdk-message-translate.test.ts
+++ b/src/agent/sdk-message-translate.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, test } from 'bun:test';
+import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
+import { translateSdkMessage, displayToolName, type TranslateContext } from './sdk-message-translate.js';
+import type { AgentEvent } from './types.js';
+
+class Recorder {
+  readonly seenTools: string[] = [];
+  readonly finalAnswers: string[] = [];
+  terminals = 0;
+  readonly ctx: TranslateContext;
+  constructor(overrides: Partial<TranslateContext> = {}) {
+    this.ctx = {
+      model: 'claude-fable-5',
+      maxTurns: 40,
+      onToolSeen: (n) => this.seenTools.push(n),
+      onFinalAnswer: (t) => this.finalAnswers.push(t),
+      onTerminal: () => { this.terminals += 1; },
+      ...overrides,
+    };
+  }
+}
+
+function ctx(overrides: Partial<TranslateContext> = {}): Recorder {
+  return new Recorder(overrides);
+}
+
+// Helper to cast a synthetic object to SDKMessage for the pure translator.
+const msg = (m: Record<string, unknown>): SDKMessage => m as unknown as SDKMessage;
+
+describe('translateSdkMessage — assistant', () => {
+  test('text-only assistant sets final answer, no thinking', () => {
+    const c = ctx();
+    const events = translateSdkMessage(
+      msg({ type: 'assistant', message: { content: [{ type: 'text', text: 'Hello' }] } }),
+      c.ctx,
+    );
+    expect(events).toHaveLength(0);
+    expect(c.finalAnswers).toContain('Hello');
+  });
+
+  test('tool_use emits tool_start and records tool seen', () => {
+    const c = ctx();
+    const events = translateSdkMessage(
+      msg({
+        type: 'assistant',
+        message: {
+          content: [
+            { type: 'text', text: 'let me check' },
+            { type: 'tool_use', id: 'tu1', name: 'mcp__dexter__get_key_ratios', input: { ticker: '7203' } },
+          ],
+        },
+      }),
+      c.ctx,
+    );
+    const starts = events.filter((e) => e.type === 'tool_start');
+    expect(starts).toHaveLength(1);
+    const start = starts[0] as Extract<AgentEvent, { type: 'tool_start' }>;
+    expect(start.tool).toBe('get_key_ratios'); // namespace stripped
+    expect(start.toolCallId).toBe('tu1');
+    expect(start.args).toEqual({ ticker: '7203' });
+    expect(c.seenTools).toContain('mcp__dexter__get_key_ratios');
+    // Accompanying text becomes a thinking line when tools are also present.
+    expect(events.some((e) => e.type === 'thinking')).toBe(true);
+  });
+
+  test('assistant error surfaces a thinking line', () => {
+    const c = ctx();
+    const events = translateSdkMessage(
+      msg({ type: 'assistant', error: 'model_not_found', message: { content: [] } }),
+      c.ctx,
+    );
+    const thinking = events.find((e) => e.type === 'thinking') as Extract<AgentEvent, { type: 'thinking' }>;
+    expect(thinking).toBeDefined();
+    expect(thinking.message).toContain("claude-fable-5");
+  });
+
+  test('thinking block is surfaced', () => {
+    const c = ctx();
+    const events = translateSdkMessage(
+      msg({ type: 'assistant', message: { content: [{ type: 'thinking', thinking: 'reasoning…' }] } }),
+      c.ctx,
+    );
+    expect(events).toEqual([{ type: 'thinking', message: 'reasoning…' }]);
+  });
+});
+
+describe('translateSdkMessage — result (terminal)', () => {
+  test('success result captures answer, marks terminal, extracts usage', () => {
+    const c = ctx();
+    const events = translateSdkMessage(
+      msg({
+        type: 'result',
+        subtype: 'success',
+        result: 'The answer is 42.',
+        usage: { input_tokens: 100, output_tokens: 20 },
+      }),
+      c.ctx,
+    );
+    expect(events).toHaveLength(0); // translator does not emit `done` itself
+    expect(c.finalAnswers).toContain('The answer is 42.');
+    expect(c.terminals).toBe(1);
+  });
+
+  test.each([
+    ['error_max_turns', 'maximum number of turns'],
+    ['error_max_budget_usd', 'cost budget'],
+    ['error_during_execution', 'Error during execution'],
+  ])('error result %s produces a descriptive answer + terminal', (subtype, needle) => {
+    const c = ctx();
+    translateSdkMessage(msg({ type: 'result', subtype, errors: [] }), c.ctx);
+    expect(c.terminals).toBe(1);
+    expect(c.finalAnswers.join(' ')).toContain(needle);
+  });
+
+  test('usage callback receives tokens including cache', () => {
+    let usage: unknown;
+    const c = ctx({ onUsage: (u) => { usage = u; } });
+    translateSdkMessage(
+      msg({
+        type: 'result',
+        subtype: 'success',
+        result: 'x',
+        usage: { input_tokens: 10, output_tokens: 5, cache_read_input_tokens: 3 },
+      }),
+      c.ctx,
+    );
+    expect(usage).toEqual({ inputTokens: 13, outputTokens: 5, totalTokens: 18 });
+  });
+});
+
+describe('translateSdkMessage — system subtypes', () => {
+  test('init emits nothing', () => {
+    const c = ctx();
+    expect(translateSdkMessage(msg({ type: 'system', subtype: 'init' }), c.ctx)).toHaveLength(0);
+  });
+
+  test('permission_denied surfaces a blocked line', () => {
+    const c = ctx();
+    const events = translateSdkMessage(
+      msg({ type: 'system', subtype: 'permission_denied', tool_name: 'Bash', message: 'nope' }),
+      c.ctx,
+    );
+    const t = events[0] as Extract<AgentEvent, { type: 'thinking' }>;
+    expect(t.type).toBe('thinking');
+    expect(t.message).toContain('Blocked tool');
+    expect(t.message).toContain('Bash');
+  });
+
+  test('api_retry surfaces a retry line', () => {
+    const c = ctx();
+    const events = translateSdkMessage(
+      msg({ type: 'system', subtype: 'api_retry', attempt: 2, max_retries: 5, error: 'overloaded' }),
+      c.ctx,
+    );
+    expect((events[0] as { message: string }).message).toContain('Retrying');
+  });
+
+  test('unknown system subtype emits nothing (quiet)', () => {
+    const c = ctx();
+    expect(translateSdkMessage(msg({ type: 'system', subtype: 'zzz_future' }), c.ctx)).toHaveLength(0);
+  });
+});
+
+describe('translateSdkMessage — other top-level types', () => {
+  test('tool_progress maps to tool_progress event', () => {
+    const c = ctx();
+    const events = translateSdkMessage(
+      msg({ type: 'tool_progress', tool_name: 'mcp__dexter__get_earnings', tool_use_id: 'x', elapsed_time_seconds: 3.4 }),
+      c.ctx,
+    );
+    const p = events[0] as Extract<AgentEvent, { type: 'tool_progress' }>;
+    expect(p.type).toBe('tool_progress');
+    expect(p.tool).toBe('get_earnings');
+    expect(p.toolCallId).toBe('x');
+  });
+
+  test('auth_status error surfaces a line; healthy auth_status is quiet', () => {
+    const c = ctx();
+    expect(translateSdkMessage(msg({ type: 'auth_status', isAuthenticating: false }), c.ctx)).toHaveLength(0);
+    const withErr = translateSdkMessage(msg({ type: 'auth_status', error: 'bad token' }), c.ctx);
+    expect(withErr).toHaveLength(1);
+  });
+
+  test('rate_limit_event only surfaces degraded status', () => {
+    const c = ctx();
+    expect(
+      translateSdkMessage(msg({ type: 'rate_limit_event', rate_limit_info: { status: 'allowed' } }), c.ctx),
+    ).toHaveLength(0);
+    expect(
+      translateSdkMessage(msg({ type: 'rate_limit_event', rate_limit_info: { status: 'rejected' } }), c.ctx),
+    ).toHaveLength(1);
+  });
+
+  test.each(['user', 'stream_event', 'tool_use_summary', 'prompt_suggestion'])(
+    'informational type %s emits nothing',
+    (type) => {
+      const c = ctx();
+      expect(translateSdkMessage(msg({ type }), c.ctx)).toHaveLength(0);
+    },
+  );
+
+  test('UNKNOWN top-level type degrades to a diagnostic thinking line (never dropped)', () => {
+    const c = ctx();
+    const events = translateSdkMessage(msg({ type: 'some_future_frame_v9' }), c.ctx);
+    expect(events).toHaveLength(1);
+    const t = events[0] as Extract<AgentEvent, { type: 'thinking' }>;
+    expect(t.type).toBe('thinking');
+    expect(t.message).toContain('unhandled message type');
+    expect(t.message).toContain('some_future_frame_v9');
+  });
+});
+
+describe('displayToolName', () => {
+  test('strips the mcp__dexter__ prefix', () => {
+    expect(displayToolName('mcp__dexter__get_key_ratios')).toBe('get_key_ratios');
+    expect(displayToolName('AskUserQuestion')).toBe('AskUserQuestion');
+  });
+});

--- a/src/agent/sdk-message-translate.ts
+++ b/src/agent/sdk-message-translate.ts
@@ -1,0 +1,227 @@
+/**
+ * Pure SDKMessage → Dexter AgentEvent translation.
+ *
+ * Kept separate from AgentSdkAgent so the EXHAUSTIVE switch over the SDKMessage
+ * union can be unit-tested with synthetic messages, with no SDK subprocess.
+ *
+ * Contract: every message maps to zero or more AgentEvents. An UNKNOWN top-level
+ * `type` degrades to a single `thinking` diagnostic (never dropped silently). The
+ * translator never yields a `done` for non-terminal frames — the caller owns turn
+ * termination and spinner-close so it can guarantee a `done` even if the stream
+ * ends abruptly.
+ */
+import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
+import type { AgentEvent, TokenUsage } from './types.js';
+
+export const DEXTER_MCP_PREFIX = 'mcp__dexter__';
+
+export interface TranslateContext {
+  /** Model id, used for error-message wording. */
+  model: string;
+  /** Max turns, used for max-turns error wording. */
+  maxTurns: number;
+  /** Records tool_use names seen (for the "no built-ins" audit). */
+  onToolSeen?: (name: string) => void;
+  /** Receives the final answer text when a success/terminal result arrives. */
+  onFinalAnswer?: (text: string) => void;
+  /** Receives usage when a result message arrives. */
+  onUsage?: (usage: TokenUsage | undefined) => void;
+  /** Signals a terminal result was translated (caller stops emitting its own done). */
+  onTerminal?: () => void;
+}
+
+/** Strip the mcp__dexter__ namespace for display. */
+export function displayToolName(name: string): string {
+  return name.startsWith(DEXTER_MCP_PREFIX) ? name.slice(DEXTER_MCP_PREFIX.length) : name;
+}
+
+function describeAssistantError(kind: string, model: string): string {
+  switch (kind) {
+    case 'model_not_found':
+      return `Model '${model}' was not found. Try a supported model (claude-fable-5, claude-opus-4-8, claude-sonnet-4-6).`;
+    case 'rate_limit':
+      return 'Rate limit reached. Wait and retry, or check your Claude plan limits.';
+    case 'authentication_failed':
+      return 'Authentication failed. Ensure you are logged in to Claude Code, or that your credentials are valid.';
+    case 'oauth_org_not_allowed':
+      return 'Your organization is not allowed to use the Agent SDK with this login. See Anthropic help.';
+    case 'billing_error':
+      return 'A billing error occurred on the resolved credential path.';
+    case 'overloaded':
+      return 'The service is temporarily overloaded. Retry shortly.';
+    case 'max_output_tokens':
+      return 'The response hit the maximum output length.';
+    default:
+      return `Assistant error: ${kind}`;
+  }
+}
+
+function describeResultError(subtype: string, errors: string[], maxTurns: number): string {
+  const detail = errors.length ? ` (${errors.join('; ')})` : '';
+  switch (subtype) {
+    case 'error_max_turns':
+      return `Reached the maximum number of turns (${maxTurns}). The task did not complete in the allotted steps.${detail}`;
+    case 'error_max_budget_usd':
+      return `Stopped: reached the configured cost budget.${detail}`;
+    case 'error_max_structured_output_retries':
+      return `Stopped: could not produce valid structured output.${detail}`;
+    case 'error_during_execution':
+    default:
+      return `Error during execution${detail || '.'}`;
+  }
+}
+
+function extractUsage(message: unknown): TokenUsage | undefined {
+  const usage = (message as { usage?: Record<string, unknown> }).usage;
+  if (!usage || typeof usage !== 'object') return undefined;
+  const input = Number(usage.input_tokens ?? 0);
+  const output = Number(usage.output_tokens ?? 0);
+  const cacheRead = Number(usage.cache_read_input_tokens ?? 0);
+  const cacheCreate = Number(usage.cache_creation_input_tokens ?? 0);
+  const total = input + output + cacheRead + cacheCreate;
+  if (total === 0) return undefined;
+  return { inputTokens: input + cacheRead + cacheCreate, outputTokens: output, totalTokens: total };
+}
+
+/**
+ * Translate one SDKMessage into AgentEvents (excluding the terminal `done`, which
+ * the caller emits so it can guarantee one even on abrupt stream end — except for
+ * `result`, where the answer text is captured via onFinalAnswer/onTerminal).
+ */
+export function translateSdkMessage(message: SDKMessage, ctx: TranslateContext): AgentEvent[] {
+  const events: AgentEvent[] = [];
+
+  switch (message.type) {
+    case 'assistant': {
+      const errKind = (message as { error?: string }).error;
+      if (errKind) {
+        events.push({ type: 'thinking', message: describeAssistantError(errKind, ctx.model) });
+      }
+      const content = ((message as { message?: { content?: unknown[] } }).message?.content ?? []) as Array<
+        Record<string, unknown>
+      >;
+      let text = '';
+      const hasToolUse = content.some((b) => b.type === 'tool_use');
+      for (const block of content) {
+        const t = block.type as string | undefined;
+        if (t === 'text' && typeof block.text === 'string') {
+          text += block.text;
+        } else if (t === 'thinking' && typeof block.thinking === 'string' && block.thinking.trim()) {
+          events.push({ type: 'thinking', message: block.thinking.trim() });
+        } else if (t === 'tool_use') {
+          const name = String(block.name ?? 'tool');
+          ctx.onToolSeen?.(name);
+          events.push({
+            type: 'tool_start',
+            tool: displayToolName(name),
+            args: (block.input as Record<string, unknown> | undefined) ?? {},
+            toolCallId: String(block.id ?? ''),
+          });
+        }
+      }
+      if (text.trim()) {
+        ctx.onFinalAnswer?.(text);
+        if (hasToolUse) events.push({ type: 'thinking', message: text.trim() });
+      }
+      return events;
+    }
+
+    case 'result': {
+      const usage = extractUsage(message);
+      ctx.onUsage?.(usage);
+      const subtype = (message as { subtype?: string }).subtype ?? '';
+      if (subtype === 'success') {
+        ctx.onFinalAnswer?.((message as { result?: string }).result ?? '');
+      } else {
+        const errors = (message as { errors?: string[] }).errors ?? [];
+        ctx.onFinalAnswer?.(describeResultError(subtype, errors, ctx.maxTurns));
+      }
+      ctx.onTerminal?.();
+      return events;
+    }
+
+    case 'system': {
+      const subtype = (message as { subtype?: string }).subtype;
+      switch (subtype) {
+        case 'init':
+          return events;
+        case 'permission_denied': {
+          const toolName = (message as { tool_name?: string }).tool_name ?? 'tool';
+          const reason = (message as { message?: string }).message;
+          events.push({
+            type: 'thinking',
+            message: `Blocked tool '${displayToolName(toolName)}'${reason ? `: ${reason}` : ''}`,
+          });
+          return events;
+        }
+        case 'api_retry': {
+          const attempt = (message as { attempt?: number }).attempt;
+          const max = (message as { max_retries?: number }).max_retries;
+          const err = (message as { error?: string }).error;
+          events.push({
+            type: 'thinking',
+            message: `Retrying API call (attempt ${attempt ?? '?'}/${max ?? '?'})${err ? ` after ${err}` : ''}…`,
+          });
+          return events;
+        }
+        case 'model_refusal_fallback':
+        case 'model_refusal_no_fallback': {
+          const content = (message as { content?: string }).content;
+          events.push({ type: 'thinking', message: content ? `Model refusal: ${content}` : 'Model refused the request.' });
+          return events;
+        }
+        case 'compact_boundary':
+          events.push({ type: 'thinking', message: 'Context compacted.' });
+          return events;
+        default:
+          return events;
+      }
+    }
+
+    case 'tool_progress': {
+      const name = (message as { tool_name?: string }).tool_name ?? 'tool';
+      const id = (message as { tool_use_id?: string }).tool_use_id;
+      const secs = (message as { elapsed_time_seconds?: number }).elapsed_time_seconds;
+      events.push({
+        type: 'tool_progress',
+        tool: displayToolName(name),
+        message: secs !== undefined ? `Working… ${Math.round(secs)}s` : 'Working…',
+        toolCallId: id,
+      });
+      return events;
+    }
+
+    case 'auth_status': {
+      const authing = (message as { isAuthenticating?: boolean }).isAuthenticating;
+      const err = (message as { error?: string }).error;
+      if (err) events.push({ type: 'thinking', message: `Authentication issue: ${err}` });
+      else if (authing) events.push({ type: 'thinking', message: 'Authenticating…' });
+      return events;
+    }
+
+    case 'rate_limit_event': {
+      const info = (message as { rate_limit_info?: { status?: string } }).rate_limit_info;
+      const status = info?.status;
+      if (status && status !== 'allowed' && status !== 'allowed_warning') {
+        events.push({ type: 'thinking', message: `Rate limit status: ${status}` });
+      }
+      return events;
+    }
+
+    case 'user':
+    case 'stream_event':
+    case 'tool_use_summary':
+    case 'prompt_suggestion':
+      // No Dexter UI equivalent — intentionally emit nothing.
+      return events;
+
+    default:
+      // Exhaustiveness guard: unknown/future top-level type degrades to a
+      // diagnostic thinking line and is never silently dropped.
+      events.push({
+        type: 'thinking',
+        message: `[sdk] unhandled message type: ${String((message as { type?: string }).type)}`,
+      });
+      return events;
+  }
+}

--- a/src/agent/sdk-prompt.ts
+++ b/src/agent/sdk-prompt.ts
@@ -1,0 +1,78 @@
+/**
+ * System prompt for Claude Agent SDK mode.
+ *
+ * Reuses Dexter's soul + user rules and the load-bearing data-integrity guardrails
+ * (identifier integrity, listing status), but describes the ACTUAL raw tools
+ * exposed in SDK mode — not the LangChain registry's NL-routing meta-tools. The
+ * SDK also gives the model the real tool schemas via MCP, so this prompt focuses
+ * on when to use each tool and how to stay accurate.
+ */
+import { getCurrentDate, loadSoulDocument, loadRulesDocument } from './prompts.js';
+
+const SDK_TOOL_POLICY = `## Available data tools
+
+You have Dexter's Japanese-market research tools (exposed as \`mcp__dexter__*\`):
+
+- **get_key_ratios**: latest financial metrics snapshot for one company (ROE, margins, EPS, PER, equity ratio, credit score, industry).
+- **get_analysis**: AI analysis, health scoring, and industry benchmarks for one company.
+- **get_financial_statements**: historical financial time series (revenue, income, assets, equity, cash flows) for trend analysis.
+- **get_company_info**: company facts (name, industry, securities code, accounting standard, latest financials).
+- **get_earnings**: recent earnings disclosures (TDNet 決算短信).
+- **get_shareholders**: large shareholding reports (大量保有報告書, 5%+ holders).
+- **read_filings**: securities report text (事業の状況, 事業等のリスク, MD&A, 経営方針) or shareholder data — pass a ticker and type.
+- **get_text_blocks**: raw annual-report text blocks for a company.
+- **screen_companies**: screen listed companies by explicit financial conditions. Supply the conditions array directly (metric key + operator gte/lte/gt/lt/eq + threshold in display units), plus optional industry / limit / sort.
+- **get_stock_price** (when available): OHLC + volume from J-Quants (TSE official).
+- **web_search** (when available): current web information the structured tools do not cover.
+
+## Tool usage policy
+
+- These tools return RAW data. Read the results and reason over them yourself.
+- Securities codes and company names both work as tickers (e.g. '7203' or 'トヨタ' or 'E02144').
+- Use the smallest set of calls that answers the question; independent reads can be issued together.
+- **Identifier integrity**: any securities code (e.g. 7203) or EDINET code (e.g. E02144) you put in your answer MUST come from a tool result (get_company_info / get_financial_statements / screen_companies), never from memory. If unsure of a code, look it up first or omit it — never guess.
+- **Listing status**: before presenting a company as currently listed or as a current/future candidate (e.g. a takeover target), verify its listing status. If a tool result shows is_delisted=true (or listing_status="delisted"), say so explicitly and do not present it as active.
+- For factual questions about entities whose state can change, verify with tools. Answer directly only for stable definitions, historical facts, or conversational turns.
+- If you need clarification from the user, ask a concise question.
+- Respond in the same language the user uses (Japanese or English).`;
+
+/**
+ * Build the SDK-mode system prompt. Best-effort loads soul/rules; if the
+ * filesystem docs are unavailable it still returns a complete prompt.
+ */
+export async function buildSdkAgentSystemPrompt(model: string, channel?: string): Promise<string> {
+  void model; // model does not change the prompt today; kept for signature parity.
+  const surface = channel === undefined || channel === 'cli' ? 'CLI' : channel;
+
+  let soul: string | null = null;
+  let rules: string | null = null;
+  try {
+    soul = await loadSoulDocument();
+  } catch {
+    soul = null;
+  }
+  try {
+    rules = await loadRulesDocument();
+  } catch {
+    rules = null;
+  }
+
+  const parts: string[] = [
+    `You are Dexter, a ${surface} assistant specialized in Japanese stock market research.`,
+    `Current date: ${getCurrentDate()}`,
+  ];
+
+  if (soul && soul.trim()) {
+    parts.push(`## About you\n\n${soul.trim()}`);
+  }
+
+  parts.push(SDK_TOOL_POLICY);
+
+  if (rules && rules.trim()) {
+    parts.push(
+      `## Research rules\n\nThe following rules were set by the user. Follow them on every query.\n\n${rules.trim()}`,
+    );
+  }
+
+  return parts.join('\n\n');
+}

--- a/src/agent/sdk-tool-adapter.test.ts
+++ b/src/agent/sdk-tool-adapter.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  buildDexterSdkTools,
+  buildDexterMcpServer,
+  dexterAllowedToolNames,
+  DEXTER_MCP_SERVER_NAME,
+} from './sdk-tool-adapter.js';
+
+/** The raw (no-internal-LLM) tools that must always be present in SDK mode. */
+const CORE_TOOL_NAMES = [
+  'get_key_ratios',
+  'get_analysis',
+  'get_financial_statements',
+  'get_company_info',
+  'get_earnings',
+  'get_shareholders',
+  'get_text_blocks',
+  'read_filings',
+  'screen_companies',
+];
+
+/** Meta-tools that route via an internal LLM — must NOT be exposed raw. */
+const EXCLUDED_TOOL_NAMES = ['get_financials', 'company_screener', 'web_fetch', 'browser', 'spawn_subagent', 'skill'];
+
+describe('buildDexterSdkTools', () => {
+  const tools = buildDexterSdkTools();
+  const names = tools.map((t) => (t as { name?: string }).name ?? '');
+
+  test('exposes all core raw finance tools', () => {
+    for (const name of CORE_TOOL_NAMES) {
+      expect(names).toContain(name);
+    }
+  });
+
+  test('does not expose internal-LLM meta-tools or SDK-builtin overlaps', () => {
+    for (const name of EXCLUDED_TOOL_NAMES) {
+      expect(names).not.toContain(name);
+    }
+  });
+
+  test('every tool carries a non-empty description and an object input schema', () => {
+    for (const t of tools) {
+      const def = t as { name?: string; description?: string; inputSchema?: unknown };
+      expect(typeof def.name).toBe('string');
+      expect(def.name && def.name.length).toBeGreaterThan(0);
+      expect(typeof def.description).toBe('string');
+      expect(def.description && def.description.length).toBeGreaterThan(0);
+      // Raw zod shape object (name → ZodType). Must be a plain object, not undefined.
+      expect(def.inputSchema).toBeDefined();
+      expect(typeof def.inputSchema).toBe('object');
+    }
+  });
+
+  test('tool names are unique', () => {
+    expect(new Set(names).size).toBe(names.length);
+  });
+});
+
+describe('buildDexterMcpServer', () => {
+  test('builds an in-process (sdk) server named "dexter" holding the raw tools', () => {
+    const { server, toolNames } = buildDexterMcpServer();
+    const s = server as { type?: string; name?: string; instance?: unknown };
+    expect(s.type).toBe('sdk');
+    expect(s.name).toBe(DEXTER_MCP_SERVER_NAME);
+    expect(s.instance).toBeDefined();
+    for (const name of CORE_TOOL_NAMES) {
+      expect(toolNames).toContain(name);
+    }
+  });
+});
+
+describe('dexterAllowedToolNames', () => {
+  test('produces the wildcard plus fully-qualified names', () => {
+    const allowed = dexterAllowedToolNames([{ name: 'get_key_ratios' }, { name: 'read_filings' }]);
+    expect(allowed).toContain(`mcp__${DEXTER_MCP_SERVER_NAME}__*`);
+    expect(allowed).toContain(`mcp__${DEXTER_MCP_SERVER_NAME}__get_key_ratios`);
+    expect(allowed).toContain(`mcp__${DEXTER_MCP_SERVER_NAME}__read_filings`);
+  });
+});

--- a/src/agent/sdk-tool-adapter.ts
+++ b/src/agent/sdk-tool-adapter.ts
@@ -1,0 +1,154 @@
+/**
+ * Adapts Dexter's LangChain tools into an in-process Claude Agent SDK MCP server.
+ *
+ * Design constraints (from the SDK-mode design doc §4-1):
+ *   - Tools return RAW data. No tool re-invokes an LLM internally; the main SDK
+ *     model interprets the raw results itself. So we expose the leaf finance
+ *     tools (which hit EDINET DB directly) rather than the NL-routing meta-tools
+ *     (`get_financials`, `company_screener`) that call `callLlm()` internally.
+ *   - The resulting MCP server is registered under the name `dexter`, so tools are
+ *     namespaced `mcp__dexter__<tool_name>` to the SDK.
+ */
+import { z } from 'zod';
+import type { StructuredToolInterface } from '@langchain/core/tools';
+import { tool, createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
+import type { McpSdkServerConfigWithInstance } from '@anthropic-ai/claude-agent-sdk';
+
+import {
+  getFinancials,
+  getCompanyInfo,
+  getKeyRatios,
+  getAnalysis,
+  getEarnings,
+  getShareholders,
+  getTextBlocks,
+  getStockPrice,
+  isJQuantsAvailable,
+  createReadFilings,
+} from '../tools/finance/index.js';
+import { createRawScreener } from '../tools/finance/raw-screener.js';
+import { buildWebSearchToolForSdk } from '../tools/search/index.js';
+
+/** Server name → tool names are exposed to the model as `mcp__dexter__<name>`. */
+export const DEXTER_MCP_SERVER_NAME = 'dexter';
+
+/**
+ * Extract a plain zod raw shape (`{ field: ZodType }`) from a LangChain tool's
+ * schema. The SDK's `tool()` wants a raw shape, not a `z.object(...)`. Leaf tools
+ * in this repo all use `z.object({...})`, so `.shape` is present. If a tool ever
+ * ships a bare JSON schema instead, we fall back to a permissive passthrough so
+ * the adapter never throws at construction time.
+ */
+function extractRawShape(schema: unknown): z.ZodRawShape {
+  const s = schema as { shape?: z.ZodRawShape; _def?: { shape?: unknown } } | undefined;
+  if (s && typeof s === 'object') {
+    if (s.shape && typeof s.shape === 'object') {
+      return s.shape;
+    }
+    // zod v4 keeps shape under _def in some builds; probe defensively.
+    const defShape = s._def?.shape;
+    if (typeof defShape === 'function') {
+      try {
+        const resolved = (defShape as () => z.ZodRawShape)();
+        if (resolved && typeof resolved === 'object') return resolved;
+      } catch {
+        /* fall through to passthrough */
+      }
+    } else if (defShape && typeof defShape === 'object') {
+      return defShape as z.ZodRawShape;
+    }
+  }
+  // Permissive fallback: accept an arbitrary JSON args object.
+  return { input: z.record(z.string(), z.unknown()).optional().describe('Tool arguments') };
+}
+
+/** Stringify whatever a LangChain tool returns into a single text block. */
+function stringifyToolResult(raw: unknown): string {
+  if (typeof raw === 'string') return raw;
+  try {
+    return JSON.stringify(raw);
+  } catch {
+    return String(raw);
+  }
+}
+
+/**
+ * Wrap one LangChain StructuredTool as an SDK tool. The handler invokes the
+ * underlying tool and returns its raw output as a text block, mapping thrown
+ * errors to `isError: true` so the SDK agent loop keeps going (per SDK docs:
+ * an uncaught throw ends the whole query()).
+ */
+function adaptLangChainTool(lcTool: StructuredToolInterface, readOnly: boolean) {
+  const shape = extractRawShape(lcTool.schema);
+  return tool(
+    lcTool.name,
+    typeof lcTool.description === 'string' ? lcTool.description : lcTool.name,
+    shape,
+    async (args: Record<string, unknown>) => {
+      try {
+        const raw = await lcTool.invoke(args as never);
+        return { content: [{ type: 'text' as const, text: stringifyToolResult(raw) }] };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${message}` }],
+          isError: true,
+        };
+      }
+    },
+    { annotations: { readOnlyHint: readOnly } },
+  );
+}
+
+/**
+ * The raw, no-internal-LLM tools we expose in SDK mode. All are read-only
+ * (financial data reads), so the SDK may batch them in parallel.
+ */
+export function buildDexterSdkTools(): ReturnType<typeof adaptLangChainTool>[] {
+  const rawTools: StructuredToolInterface[] = [
+    // Leaf finance tools — hit EDINET DB directly, no internal LLM.
+    getKeyRatios,
+    getAnalysis,
+    getFinancials,
+    getCompanyInfo,
+    getEarnings,
+    getShareholders,
+    getTextBlocks,
+    // read_filings ignores its `model` arg (no internal LLM), safe as-is.
+    createReadFilings(''),
+    // Structured screener — main model supplies conditions directly (no NL→LLM step).
+    createRawScreener(),
+  ];
+
+  // Optional raw tools gated by env.
+  if (isJQuantsAvailable()) {
+    rawTools.push(getStockPrice);
+  }
+  const webSearch = buildWebSearchToolForSdk();
+  if (webSearch) {
+    rawTools.push(webSearch);
+  }
+
+  return rawTools.map((t) => adaptLangChainTool(t, /* readOnly */ true));
+}
+
+/** The fully-qualified tool names the SDK should auto-approve (allowlist). */
+export function dexterAllowedToolNames(tools: { name: string }[]): string[] {
+  // The `tool()` helper stores the tool name; the SDK namespaces it as
+  // mcp__<server>__<name>. A wildcard covers all tools on the server.
+  return [`mcp__${DEXTER_MCP_SERVER_NAME}__*`, ...tools.map((t) => `mcp__${DEXTER_MCP_SERVER_NAME}__${t.name}`)];
+}
+
+/** Build the in-process MCP server holding the raw Dexter tools. */
+export function buildDexterMcpServer(): {
+  server: McpSdkServerConfigWithInstance;
+  toolNames: string[];
+} {
+  const tools = buildDexterSdkTools();
+  const server = createSdkMcpServer({
+    name: DEXTER_MCP_SERVER_NAME,
+    version: '1.0.0',
+    tools,
+  });
+  return { server, toolNames: tools.map((t) => (t as { name?: string }).name ?? '') };
+}

--- a/src/agent/tool-executor.ts
+++ b/src/agent/tool-executor.ts
@@ -13,6 +13,7 @@ import type {
   ToolProgressEvent,
   ToolStartEvent,
 } from './types.js';
+import type { Question, UserAnswers } from '../tools/ask-user-question/types.js';
 import type { RunContext } from './run-context.js';
 
 type ToolExecutionEvent =
@@ -53,6 +54,9 @@ export class AgentToolExecutor {
     }) => Promise<ApprovalDecision>,
     sessionApprovedTools?: Set<string>,
     maxConcurrency?: number,
+    private readonly requestUserInput?: (request: {
+      questions: Question[];
+    }) => Promise<UserAnswers>,
   ) {
     this.sessionApprovedTools = sessionApprovedTools ?? new Set();
     this.maxConcurrency = maxConcurrency ?? DEFAULT_MAX_CONCURRENCY;
@@ -162,7 +166,10 @@ export class AgentToolExecutor {
 
       const channel = createProgressChannel();
       const config = {
-        metadata: { onProgress: channel.emit },
+        metadata: {
+          onProgress: channel.emit,
+          ...(this.requestUserInput ? { onUserInput: this.requestUserInput } : {}),
+        },
         ...(this.signal ? { signal: this.signal } : {}),
       };
 

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -1,5 +1,6 @@
 import type { GroupContext } from './prompts.js';
 import type { MessageQueue } from '../utils/message-queue.js';
+import type { Question, UserAnswers } from '../tools/ask-user-question/types.js';
 
 // ============================================================================
 // Channel Profiles
@@ -52,6 +53,8 @@ export interface AgentConfig {
   groupContext?: GroupContext;
   /** Called when a tool needs explicit user approval to proceed */
   requestToolApproval?: (request: { tool: string; args: Record<string, unknown> }) => Promise<ApprovalDecision>;
+  /** CLI-only: called when the agent asks the user interactive questions mid-turn. */
+  requestUserInput?: (request: { questions: Question[] }) => Promise<UserAnswers>;
   /** Shared set of tool names that have been session-approved (persists across queries) */
   sessionApprovedTools?: Set<string>;
   /** Enable/disable persistent memory integration for this run */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -305,6 +305,7 @@ export async function runCli() {
 
   const errorText = new Text('', 0, 0);
   const workingIndicator = new WorkingIndicatorComponent(tui);
+  workingIndicator.setTurnStatsProvider(() => agentRunner.turnStats);
   const editor = new CustomEditor(tui, editorTheme);
   const hintBar = new HintBarComponent();
   const debugPanel = new DebugPanelComponent(8, true);
@@ -504,7 +505,6 @@ export async function runCli() {
     }
     if (
       !modelSelection.isInSelectionFlow() &&
-      !searchSelection.isInSelectionFlow() &&
       !agentRunner.pendingApproval &&
       !agentRunner.pendingQuestion
     ) {
@@ -563,10 +563,8 @@ export async function runCli() {
 
   const renderSelectionOverlay = () => {
     const state = modelSelection.state;
-    const searchState = searchSelection.state;
     if (
       state.appState === 'idle' &&
-      searchState.appState === 'idle' &&
       !agentRunner.pendingApproval &&
       !agentRunner.pendingQuestion
     ) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ import {
 import {
   ApiKeyInputComponent,
   ApprovalPromptComponent,
+  QuestionPromptComponent,
   ChatLogComponent,
   CustomEditor,
   DebugPanelComponent,
@@ -123,6 +124,11 @@ function renderEvent(
 
   if (event.type === 'tool_start') {
     const toolStart = event as ToolStartEvent;
+    // ask_user_question has no tool row: the inline widget is its UI, and an
+    // answered block is appended on submit. (matches the no-tool-message design)
+    if (toolStart.tool === 'ask_user_question') {
+      return;
+    }
     const component = chatLog.startTool(display.id, toolStart.tool, toolStart.args);
     if (display.completed && display.endEvent?.type === 'tool_end') {
       const done = display.endEvent as ToolEndEvent;
@@ -197,6 +203,12 @@ export async function runCli() {
   let lastRenderedStatus = '';
   let lastRenderedAnswer = false;
   const finalizedToolIds = new Set<string>();
+  const appliedToolProgress = new Map<string, string>();
+  let lastPendingApproval: { tool: string; args: Record<string, unknown> } | null = null;
+  let lastPendingQuestion: { questions: unknown[] } | null = null;
+  // Cached so the stateful question overlay survives onChange-driven re-renders
+  // (partial selections, active tab, in-progress text are kept across renders).
+  let activeQuestionPrompt: QuestionPromptComponent | null = null;
 
   agentRunner = new AgentRunnerController(
     { model: modelSelection.model, modelProvider: modelSelection.provider, maxIterations: 10 },
@@ -260,6 +272,14 @@ export async function runCli() {
 
       workingIndicator.setState(agentRunner.workingState);
       updateView();
+      if (agentRunner.pendingApproval !== lastPendingApproval) {
+        lastPendingApproval = agentRunner.pendingApproval;
+        renderSelectionOverlay();
+      }
+      if (agentRunner.pendingQuestion !== lastPendingQuestion) {
+        lastPendingQuestion = agentRunner.pendingQuestion;
+        renderSelectionOverlay();
+      }
       throttledRender();
     },
   );
@@ -482,7 +502,12 @@ export async function runCli() {
         queueLength: defaultQueue.length(),
       });
     }
-    if (!modelSelection.isInSelectionFlow() && !agentRunner.pendingApproval) {
+    if (
+      !modelSelection.isInSelectionFlow() &&
+      !searchSelection.isInSelectionFlow() &&
+      !agentRunner.pendingApproval &&
+      !agentRunner.pendingQuestion
+    ) {
       tui.setFocus(editor);
     }
   };
@@ -521,9 +546,31 @@ export async function runCli() {
     updateView();
   };
 
+  // Render the question widget INLINE: keep the conversation (intro + chatLog)
+  // visible and slot the widget where the input normally sits, instead of
+  // replacing the whole screen via showScreenView.
+  const showQuestionInline = () => {
+    if (!activeQuestionPrompt) return;
+    root.clear();
+    root.addChild(intro);
+    root.addChild(chatLog);
+    root.addChild(errorText);
+    root.addChild(spacer);
+    root.addChild(activeQuestionPrompt);
+    root.addChild(debugPanel);
+    tui.setFocus(activeQuestionPrompt);
+  };
+
   const renderSelectionOverlay = () => {
     const state = modelSelection.state;
-    if (state.appState === 'idle' && !agentRunner.pendingApproval) {
+    const searchState = searchSelection.state;
+    if (
+      state.appState === 'idle' &&
+      searchState.appState === 'idle' &&
+      !agentRunner.pendingApproval &&
+      !agentRunner.pendingQuestion
+    ) {
+      activeQuestionPrompt = null;
       restoreMainView();
       tui.requestRender();
       return;
@@ -538,6 +585,27 @@ export async function runCli() {
         agentRunner.respondToApproval(decision);
       };
       showScreenView('', '', prompt, undefined, prompt.selector);
+      return;
+    }
+
+    if (agentRunner.pendingQuestion) {
+      if (!activeQuestionPrompt) {
+        activeQuestionPrompt = new QuestionPromptComponent(
+          agentRunner.pendingQuestion.questions,
+          tui,
+        );
+        activeQuestionPrompt.onSubmit = (answers) => {
+          chatLog.addAnsweredQuestions(answers.answers);
+          agentRunner.respondToQuestion(answers);
+        };
+        activeQuestionPrompt.onCancel = () => {
+          agentRunner.respondToQuestion({ answers: [], declined: true });
+        };
+        activeQuestionPrompt.onAbort = () => {
+          agentRunner.cancelExecution();
+        };
+      }
+      showQuestionInline();
       return;
     }
 

--- a/src/components/chat-log.ts
+++ b/src/components/chat-log.ts
@@ -1,5 +1,6 @@
 import { Container, Spacer, Text, type TUI } from '@mariozechner/pi-tui';
 import type { TokenUsage } from '../agent/types.js';
+import type { QuestionAnswer } from '../tools/ask-user-question/types.js';
 import { theme } from '../theme.js';
 import { AnswerBoxComponent } from './answer-box.js';
 import { ToolEventComponent } from './tool-event.js';
@@ -289,6 +290,21 @@ export class ChatLogComponent extends Container {
     }
     this.activeAnswer.setText(text);
     this.activeAnswer = null;
+  }
+
+  addAnsweredQuestions(answers: QuestionAnswer[]) {
+    if (answers.length === 0) {
+      return;
+    }
+    this.addChild(new Text(`${theme.success('⏺')} ${theme.muted('Answered:')}`, 0, 0));
+    for (const a of answers) {
+      const picks = [...a.selected];
+      if (a.otherText) {
+        picks.push(a.otherText);
+      }
+      const ans = picks.length ? picks.join(', ') : '—';
+      this.addChild(new Text(`${theme.muted('⎿  ')}${theme.dim(`${a.question} → ${ans}`)}`, 0, 0));
+    }
   }
 
   addContextCleared(clearedCount: number, keptCount: number) {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,6 @@
 export { AnswerBoxComponent } from './answer-box.js';
 export { ApprovalPromptComponent } from './approval-prompt.js';
+export { QuestionPromptComponent } from './question-prompt.js';
 export { ChatLogComponent } from './chat-log.js';
 export { DebugPanelComponent } from './debug-panel.js';
 export { CustomEditor } from './custom-editor.js';

--- a/src/components/question-prompt.ts
+++ b/src/components/question-prompt.ts
@@ -1,0 +1,379 @@
+import { Container, Key, matchesKey, truncateToWidth, type TUI } from '@mariozechner/pi-tui';
+import { CustomEditor } from './custom-editor.js';
+import { editorTheme, theme } from '../theme.js';
+import type { Question, QuestionAnswer, UserAnswers } from '../tools/ask-user-question/types.js';
+
+/** Marker stored in a multi-select question's set when "Other" is chosen. */
+const OTHER_MARKER = 'Other';
+
+type Mode = 'select' | 'other';
+
+/**
+ * Interactive inline widget for the ask_user_question tool.
+ *
+ * Renders as a tab strip (one tab per question plus a Submit tab) over a numbered
+ * option list with a `❯` cursor. The component owns all keyboard input — pi-tui
+ * routes keys to a single focused component — and drives a `CustomEditor` for the
+ * "Other" free-text choice via a small mode machine.
+ *
+ * Row layout per question tab (cursor flows through all of them):
+ *   options[0..m-1] · "Type something." (Other) · "Chat about this" (decline)
+ */
+export class QuestionPromptComponent extends Container {
+  onSubmit?: (answers: UserAnswers) => void;
+  onCancel?: () => void;
+  onAbort?: () => void;
+
+  private readonly tui: TUI;
+  private readonly questions: Question[];
+  /** Index of the Submit tab (one past the last question). */
+  private readonly submitTab: number;
+  private readonly selected: Set<string>[];
+  private readonly otherText: (string | undefined)[];
+  private readonly cursors: number[];
+  private activeTab = 0;
+  private mode: Mode = 'select';
+  private editor: CustomEditor | null = null;
+
+  constructor(questions: Question[], tui: TUI) {
+    super();
+    this.tui = tui;
+    this.questions = questions;
+    this.submitTab = questions.length;
+    this.selected = questions.map(() => new Set<string>());
+    this.otherText = questions.map(() => undefined);
+    this.cursors = questions.map(() => 0);
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Input
+  // ──────────────────────────────────────────────────────────────────────────
+
+  handleInput(data: string): void {
+    if (this.mode === 'other') {
+      this.editor?.handleInput(data);
+      this.tui.requestRender();
+      return;
+    }
+
+    if (matchesKey(data, Key.ctrl('c'))) {
+      this.onAbort?.();
+      return;
+    }
+    if (matchesKey(data, Key.escape)) {
+      this.onCancel?.();
+      return;
+    }
+
+    // Tab navigation (wraps across questions + Submit).
+    if (matchesKey(data, Key.right) || matchesKey(data, Key.tab)) {
+      this.activeTab = (this.activeTab + 1) % (this.submitTab + 1);
+      this.tui.requestRender();
+      return;
+    }
+    if (matchesKey(data, Key.left) || matchesKey(data, 'shift+tab')) {
+      this.activeTab = (this.activeTab - 1 + this.submitTab + 1) % (this.submitTab + 1);
+      this.tui.requestRender();
+      return;
+    }
+
+    if (this.activeTab === this.submitTab) {
+      if (matchesKey(data, Key.enter)) {
+        this.trySubmit();
+        this.tui.requestRender();
+      }
+      return;
+    }
+
+    // Question tab — move the option cursor / act on a row.
+    const rowCount = this.rowCount(this.activeTab);
+    if (matchesKey(data, Key.up) || data === 'k') {
+      this.cursors[this.activeTab] = (this.cursors[this.activeTab] - 1 + rowCount) % rowCount;
+      this.tui.requestRender();
+      return;
+    }
+    if (matchesKey(data, Key.down) || data === 'j') {
+      this.cursors[this.activeTab] = (this.cursors[this.activeTab] + 1) % rowCount;
+      this.tui.requestRender();
+      return;
+    }
+    if (matchesKey(data, Key.enter)) {
+      this.activateRow(this.cursors[this.activeTab]);
+      this.tui.requestRender();
+      return;
+    }
+    if (
+      this.questions[this.activeTab].multiSelect &&
+      (data === ' ' || matchesKey(data, Key.space))
+    ) {
+      const idx = this.cursors[this.activeTab];
+      if (idx < this.questions[this.activeTab].options.length) {
+        this.toggleOption(idx);
+        this.tui.requestRender();
+      }
+      return;
+    }
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Row model: 0..m-1 options, m = Other, m+1 = Chat about this
+  // ──────────────────────────────────────────────────────────────────────────
+
+  private rowCount(tab: number): number {
+    return this.questions[tab].options.length + 2;
+  }
+
+  private activateRow(idx: number): void {
+    const q = this.questions[this.activeTab];
+    const m = q.options.length;
+    if (idx < m) {
+      if (q.multiSelect) {
+        this.toggleOption(idx);
+      } else {
+        this.selected[this.activeTab] = new Set([q.options[idx].label]);
+        this.otherText[this.activeTab] = undefined;
+        this.advance();
+      }
+    } else if (idx === m) {
+      this.openOther();
+    } else {
+      this.onCancel?.();
+    }
+  }
+
+  private toggleOption(idx: number): void {
+    const label = this.questions[this.activeTab].options[idx].label;
+    const set = this.selected[this.activeTab];
+    if (set.has(label)) {
+      set.delete(label);
+    } else {
+      set.add(label);
+    }
+  }
+
+  /** After a single-select answer, jump to the next unanswered tab, or Submit. */
+  private advance(): void {
+    if (this.allAnswered()) {
+      this.activeTab = this.submitTab;
+      return;
+    }
+    const n = this.questions.length;
+    for (let k = 1; k <= n; k++) {
+      const idx = (this.activeTab + k) % n;
+      if (!this.isAnswered(idx)) {
+        this.activeTab = idx;
+        return;
+      }
+    }
+  }
+
+  private trySubmit(): void {
+    if (this.allAnswered()) {
+      this.onSubmit?.({ answers: this.buildAnswers() });
+      return;
+    }
+    for (let i = 0; i < this.questions.length; i++) {
+      if (!this.isAnswered(i)) {
+        this.activeTab = i;
+        return;
+      }
+    }
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Other free-text sub-mode
+  // ──────────────────────────────────────────────────────────────────────────
+
+  private openOther(): void {
+    const tab = this.activeTab;
+    const q = this.questions[tab];
+    const editor = new CustomEditor(this.tui, editorTheme);
+    editor.focused = true;
+    if (this.otherText[tab]) {
+      editor.setText(this.otherText[tab]!);
+    }
+    editor.onCtrlC = () => this.onAbort?.();
+    editor.onEscape = () => {
+      this.mode = 'select';
+      this.editor = null;
+      this.tui.requestRender();
+    };
+    editor.onSubmit = (text: string) => {
+      const t = text.trim();
+      if (q.multiSelect) {
+        if (t) {
+          this.otherText[tab] = t;
+          this.selected[tab].add(OTHER_MARKER);
+        } else {
+          this.otherText[tab] = undefined;
+          this.selected[tab].delete(OTHER_MARKER);
+        }
+        this.mode = 'select';
+        this.editor = null;
+        this.tui.requestRender();
+      } else if (t) {
+        this.otherText[tab] = t;
+        this.selected[tab] = new Set();
+        this.mode = 'select';
+        this.editor = null;
+        this.advance();
+        this.tui.requestRender();
+      } else {
+        this.mode = 'select';
+        this.editor = null;
+        this.tui.requestRender();
+      }
+    };
+    this.editor = editor;
+    this.mode = 'other';
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Derived state
+  // ──────────────────────────────────────────────────────────────────────────
+
+  private isAnswered(i: number): boolean {
+    return this.selected[i].size > 0 || !!(this.otherText[i] && this.otherText[i]!.length > 0);
+  }
+
+  private allAnswered(): boolean {
+    return this.questions.every((_, i) => this.isAnswered(i));
+  }
+
+  private answerText(i: number): string {
+    const picks = Array.from(this.selected[i]).filter((s) => s !== OTHER_MARKER);
+    if (this.otherText[i]) {
+      picks.push(this.otherText[i]!);
+    }
+    return picks.join(', ');
+  }
+
+  private buildAnswers(): QuestionAnswer[] {
+    return this.questions.map((q, i) => ({
+      header: q.header,
+      question: q.question,
+      selected: Array.from(this.selected[i]).filter((s) => s !== OTHER_MARKER),
+      otherText: this.otherText[i] || undefined,
+    }));
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Rendering
+  // ──────────────────────────────────────────────────────────────────────────
+
+  invalidate(): void {
+    this.editor?.invalidate();
+  }
+
+  render(width: number): string[] {
+    const w = Math.max(width, 1);
+    const rule = theme.muted('─'.repeat(w));
+    const lines: string[] = [];
+
+    lines.push(rule);
+    lines.push(this.renderTabStrip());
+    lines.push('');
+
+    if (this.activeTab === this.submitTab) {
+      lines.push(...this.renderSubmit());
+    } else if (this.mode === 'other') {
+      lines.push(...this.renderOther(w));
+    } else {
+      lines.push(...this.renderQuestion(w, rule));
+    }
+
+    // pi-tui requires every rendered line to fit the live viewport width.
+    // Clip ANSI-safely (preserves color/escape sequences) — scales to any terminal.
+    return lines.map((line) => truncateToWidth(line, w, '…'));
+  }
+
+  private renderTabStrip(): string {
+    const segs: string[] = [theme.muted('←')];
+    for (let i = 0; i < this.questions.length; i++) {
+      const box = this.isAnswered(i) ? '☑' : '☐';
+      const seg = `${box} ${this.questions[i].header}`;
+      segs.push(i === this.activeTab ? theme.primary(theme.bold(seg)) : theme.muted(seg));
+    }
+    const submitSeg = '✔ Submit';
+    segs.push(
+      this.activeTab === this.submitTab ? theme.primary(theme.bold(submitSeg)) : theme.muted(submitSeg),
+    );
+    segs.push(theme.muted('→'));
+    return segs.join('  ');
+  }
+
+  private renderQuestion(width: number, rule: string): string[] {
+    const q = this.questions[this.activeTab];
+    const cursor = this.cursors[this.activeTab];
+    const lines: string[] = [];
+    lines.push(theme.bold(q.question));
+    lines.push('');
+
+    q.options.forEach((opt, idx) => {
+      lines.push(...this.renderRow(idx, cursor, this.optionLabel(idx)));
+      lines.push(`     ${theme.muted(opt.description)}`);
+    });
+
+    // Other row
+    const m = q.options.length;
+    const otherSuffix = this.otherText[this.activeTab] ? ` (${this.otherText[this.activeTab]})` : '';
+    lines.push(...this.renderRow(m, cursor, `Type something.${otherSuffix}`));
+
+    lines.push(rule);
+
+    // Chat about this row (below the rule)
+    lines.push(...this.renderRow(m + 1, cursor, 'Chat about this'));
+    lines.push('');
+    lines.push(theme.muted(this.footerHint()));
+    return lines;
+  }
+
+  private optionLabel(idx: number): string {
+    const q = this.questions[this.activeTab];
+    if (!q.multiSelect) {
+      return q.options[idx].label;
+    }
+    const checked = this.selected[this.activeTab].has(q.options[idx].label);
+    return `${checked ? '◉' : '◯'} ${q.options[idx].label}`;
+  }
+
+  private renderRow(idx: number, cursor: number, label: string): string[] {
+    const isCursor = idx === cursor;
+    const arrow = isCursor ? theme.primary('❯') : ' ';
+    const head = `${arrow} ${idx + 1}. ${label}`;
+    return [isCursor ? theme.bold(head) : head];
+  }
+
+  private renderOther(width: number): string[] {
+    const q = this.questions[this.activeTab];
+    const lines: string[] = [];
+    lines.push(theme.bold(q.question));
+    lines.push('');
+    lines.push(theme.muted('Type your answer:'));
+    lines.push(...(this.editor?.render(width) ?? []));
+    lines.push('');
+    lines.push(theme.muted('Enter save · Esc back'));
+    return lines;
+  }
+
+  private renderSubmit(): string[] {
+    const lines: string[] = [];
+    lines.push(theme.bold('Review your answers:'));
+    lines.push('');
+    this.questions.forEach((q, i) => {
+      const answer = this.isAnswered(i) ? this.answerText(i) : theme.dim('— not answered');
+      lines.push(`  ${theme.muted(q.header)}: ${answer}`);
+    });
+    lines.push('');
+    const hint = this.allAnswered()
+      ? 'Enter to submit · Tab/Arrow keys to navigate · Esc to cancel'
+      : 'Answer all questions to submit · Tab/Arrow keys to navigate · Esc to cancel';
+    lines.push(theme.muted(hint));
+    return lines;
+  }
+
+  private footerHint(): string {
+    const verb = this.questions[this.activeTab].multiSelect ? 'Enter/Space to toggle' : 'Enter to select';
+    return `${verb} · Tab/Arrow keys to navigate · Esc to cancel`;
+  }
+}

--- a/src/components/select-list.ts
+++ b/src/components/select-list.ts
@@ -3,7 +3,7 @@ import { PROVIDERS, type Model } from '../utils/model.js';
 import type { ApprovalDecision } from '../agent/types.js';
 import { selectListTheme, theme } from '../theme.js';
 
-class VimSelectList extends SelectList {
+export class VimSelectList extends SelectList {
   handleInput(keyData: string): void {
     if (keyData === 'j') {
       super.handleInput('\u001b[B');

--- a/src/components/tool-event.ts
+++ b/src/components/tool-event.ts
@@ -5,7 +5,16 @@ import { subscribeSpinner } from '../utils/spinner.js';
 
 const CIRCLE = '⏺';
 
+/** Short display names that override the default title-casing. */
+const TOOL_NAME_OVERRIDES: Record<string, string> = {
+  ask_user_question: 'Ask',
+};
+
 function formatToolName(name: string): string {
+  const override = TOOL_NAME_OVERRIDES[name];
+  if (override) {
+    return override;
+  }
   const stripped = name.replace(/^(get)_/, '');
   return stripped
     .split('_')
@@ -25,6 +34,13 @@ function truncateAtWord(str: string, maxLength: number): string {
 }
 
 function formatArgs(tool: string, args: Record<string, unknown>): string {
+  if (tool === 'ask_user_question') {
+    const questions = Array.isArray(args.questions) ? args.questions : [];
+    const headers = questions
+      .map((q) => (q && typeof q === 'object' ? (q as { header?: unknown }).header : undefined))
+      .filter((h): h is string => typeof h === 'string');
+    return theme.muted(headers.join(', '));
+  }
   if ('query' in args) {
     const query = String(args.query);
     return theme.muted(`"${truncateAtWord(query, 60)}"`);

--- a/src/components/working-indicator.ts
+++ b/src/components/working-indicator.ts
@@ -1,8 +1,17 @@
 import { Container, Spacer, Text } from '@mariozechner/pi-tui';
 import type { WorkingState } from '../types.js';
+import type { StreamMode } from '../agent/types.js';
 import { getRandomThinkingVerb } from '../utils/thinking-verbs.js';
 import { theme } from '../theme.js';
 import { subscribeSpinner, currentSpinnerFrame } from '../utils/spinner.js';
+import { formatTurnDuration, formatTokensCompact } from '../utils/format.js';
+
+export interface TurnStats {
+  turnStartMs: number;
+  streamedChars: number;
+  streamMode: StreamMode;
+}
+
 
 export class WorkingIndicatorComponent extends Container {
   private spacer: Spacer;
@@ -11,6 +20,9 @@ export class WorkingIndicatorComponent extends Container {
   private thinkingVerb = getRandomThinkingVerb();
   private prevStatus: WorkingState['status'] = 'idle';
   private unsubscribeSpinner: (() => void) | null = null;
+  private turnStatsProvider: (() => TurnStats | null) | null = null;
+  private displayedChars = 0;
+  private lastTurnStartMs: number | null = null;
 
   constructor(_tui: unknown) {
     super();
@@ -37,11 +49,17 @@ export class WorkingIndicatorComponent extends Container {
       this.stopSpinner();
       this.spacer.setLines(0);
       this.text.setText('');
+      this.displayedChars = 0;
+      this.lastTurnStartMs = null;
       return;
     }
     this.spacer.setLines(1);
     this.startSpinner();
     this.updateMessage(currentSpinnerFrame());
+  }
+
+  setTurnStatsProvider(provider: (() => TurnStats | null) | null) {
+    this.turnStatsProvider = provider;
   }
 
   dispose() {
@@ -67,7 +85,7 @@ export class WorkingIndicatorComponent extends Container {
       this.text.setText('');
       return;
     }
-    const message = this.state.status === 'approval'
+    const baseMessage = this.state.status === 'approval'
       ? 'Waiting for approval...'
       : this.state.status === 'question'
         ? 'Waiting for your answer...'

--- a/src/components/working-indicator.ts
+++ b/src/components/working-indicator.ts
@@ -69,7 +69,51 @@ export class WorkingIndicatorComponent extends Container {
     }
     const message = this.state.status === 'approval'
       ? 'Waiting for approval...'
-      : `${this.thinkingVerb}...`;
-    this.text.setText(` ${theme.primary(frame)} ${theme.primary(message)}`);
+      : this.state.status === 'question'
+        ? 'Waiting for your answer...'
+        : `${this.thinkingVerb}...`;
+
+    const suffix = this.computeStatsSuffix();
+    const fullMessage = suffix ? `${baseMessage} ${suffix}` : baseMessage;
+    this.text.setText(` ${theme.primary(frame)} ${theme.primary(fullMessage)}`);
+  }
+
+  private computeStatsSuffix(): string | null {
+    const stats = this.turnStatsProvider?.() ?? null;
+    if (!stats) return null;
+
+    // Reset the chase if we've moved into a new turn.
+    if (this.lastTurnStartMs !== stats.turnStartMs) {
+      this.displayedChars = 0;
+      this.lastTurnStartMs = stats.turnStartMs;
+    }
+
+    const elapsed = Date.now() - stats.turnStartMs;
+    this.advanceDisplayedChars(stats.streamedChars);
+    const tokens = Math.round(this.displayedChars / 4);
+    if (tokens <= 0) {
+      return theme.muted(`(${formatTurnDuration(elapsed)})`);
+    }
+    const arrow = stats.streamMode === 'requesting' ? '↑' : '↓';
+    return theme.muted(`(${formatTurnDuration(elapsed)} · ${arrow} ${formatTokensCompact(tokens)} tokens)`);
+  }
+
+  /**
+   * Smooth chase animation toward the live char count:
+   *   gap < 70  → +3
+   *   gap < 200 → max(8, ceil(gap * 0.15))
+   *   else      → +50
+   */
+  private advanceDisplayedChars(target: number) {
+    const gap = target - this.displayedChars;
+    if (gap <= 0) {
+      this.displayedChars = target;
+      return;
+    }
+    let increment: number;
+    if (gap < 70) increment = 3;
+    else if (gap < 200) increment = Math.max(8, Math.ceil(gap * 0.15));
+    else increment = 50;
+    this.displayedChars = Math.min(this.displayedChars + increment, target);
   }
 }

--- a/src/controllers/agent-runner.question.test.ts
+++ b/src/controllers/agent-runner.question.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test, mock, beforeEach, afterEach } from 'bun:test';
+import { AgentRunnerController } from './agent-runner.js';
+import { InMemoryChatHistory } from '../utils/in-memory-chat-history.js';
+import type { AgentConfig, AgentEvent } from '../agent/types.js';
+import type { Question } from '../tools/ask-user-question/types.js';
+
+const QUESTIONS: Question[] = [
+  {
+    question: 'Which ticker?',
+    header: 'Ticker',
+    multiSelect: false,
+    options: [
+      { label: 'AAPL', description: 'Apple' },
+      { label: 'MSFT', description: 'Microsoft' },
+    ],
+  },
+];
+
+function createController() {
+  const controller = new AgentRunnerController(
+    { model: 'gpt-5.5', modelProvider: 'openai', maxIterations: 10 },
+    new InMemoryChatHistory('gpt-5.5'),
+  );
+  return controller;
+}
+
+describe('AgentRunnerController — question flow', () => {
+  beforeEach(() => {
+    mock.module('../agent/agent.js', () => ({
+      Agent: class MockAgent {
+        static async create(config: AgentConfig) {
+          return new MockAgent(config);
+        }
+        constructor(private config: AgentConfig) {}
+        async *run(): AsyncGenerator<AgentEvent> {
+          const requestUserInput = this.config.requestUserInput;
+          if (requestUserInput) {
+            await requestUserInput({ questions: QUESTIONS });
+          }
+          yield { type: 'done', answer: 'done', toolCalls: [], iterations: 1, totalTime: 10 };
+        }
+      },
+    }));
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test('sets pendingQuestion and question working state while awaiting input', async () => {
+    const controller = createController();
+    expect(controller.pendingQuestion).toBeNull();
+
+    const runPromise = controller.runQuery('test');
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(controller.pendingQuestion).not.toBeNull();
+    expect(controller.pendingQuestion?.questions[0].header).toBe('Ticker');
+    expect(controller.workingState.status).toBe('question');
+
+    controller.respondToQuestion({ answers: [] });
+    await runPromise;
+  });
+
+  test('respondToQuestion clears pendingQuestion and completes the run', async () => {
+    const controller = createController();
+    const runPromise = controller.runQuery('test');
+    await new Promise((r) => setTimeout(r, 10));
+
+    controller.respondToQuestion({
+      answers: [{ header: 'Ticker', question: 'Which ticker?', selected: ['AAPL'] }],
+    });
+    await runPromise;
+
+    expect(controller.pendingQuestion).toBeNull();
+    expect(controller.workingState.status).toBe('idle');
+  });
+
+  test('cancelExecution unblocks a pending question (declined) without hanging', async () => {
+    const controller = createController();
+    const runPromise = controller.runQuery('test');
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(controller.pendingQuestion).not.toBeNull();
+
+    controller.cancelExecution();
+    await runPromise;
+
+    expect(controller.pendingQuestion).toBeNull();
+    expect(controller.workingState.status).toBe('idle');
+  });
+
+  test('respondToQuestion is a no-op when nothing is pending', () => {
+    const controller = createController();
+    expect(() => controller.respondToQuestion({ answers: [] })).not.toThrow();
+  });
+});

--- a/src/controllers/agent-runner.ts
+++ b/src/controllers/agent-runner.ts
@@ -11,6 +11,12 @@ import type { Question, UserAnswers } from '../tools/ask-user-question/types.js'
 import type { DisplayEvent, StreamMode } from '../agent/types.js';
 import type { HistoryItem, HistoryItemStatus, WorkingState } from '../types.js';
 
+export interface TurnStats {
+  turnStartMs: number;
+  streamedChars: number;
+  streamMode: StreamMode;
+}
+
 type ChangeListener = () => void;
 
 export interface RunQueryResult {
@@ -136,6 +142,7 @@ export class AgentRunnerController {
     }
     this.markLastProcessing('interrupted');
     this.workingStateValue = { status: 'idle' };
+    this.resetTurnStats();
     this.emitChange();
   }
 
@@ -156,6 +163,9 @@ export class AgentRunnerController {
     this.inMemoryChatHistory.saveUserQuery(query);
     this.errorValue = null;
     this.workingStateValue = { status: 'thinking' };
+    this.turnStartMsValue = startTime;
+    this.streamedCharsValue = 0;
+    this.streamModeValue = 'requesting';
     this.emitChange();
 
     try {
@@ -190,6 +200,7 @@ export class AgentRunnerController {
       if (error instanceof Error && error.name === 'AbortError') {
         this.markLastProcessing('interrupted');
         this.workingStateValue = { status: 'idle' };
+        this.resetTurnStats();
         this.emitChange();
         return undefined;
       }
@@ -197,11 +208,18 @@ export class AgentRunnerController {
       this.errorValue = message;
       this.markLastProcessing('error');
       this.workingStateValue = { status: 'idle' };
+      this.resetTurnStats();
       this.emitChange();
       return undefined;
     } finally {
       this.abortController = null;
     }
+  }
+
+  private resetTurnStats() {
+    this.turnStartMsValue = null;
+    this.streamedCharsValue = 0;
+    this.streamModeValue = null;
   }
 
   private requestToolApproval = (request: { tool: string; args: Record<string, unknown> }) => {
@@ -249,14 +267,16 @@ export class AgentRunnerController {
         }));
         break;
       }
-      case 'tool_progress':
+      case 'tool_progress': {
+        const progressToolId = event.toolCallId ?? this.getLastItem()?.activeToolId;
         this.updateLastItem((last) => ({
           ...last,
           events: last.events.map((entry) =>
-            entry.id === last.activeToolId ? { ...entry, progressMessage: event.message } : entry,
+            entry.id === progressToolId ? { ...entry, progressMessage: event.message } : entry,
           ),
         }));
         break;
+      }
       case 'tool_end': {
         const endToolId = event.toolCallId ?? this.getLastItem()?.activeToolId;
         this.updateLastItem((last) => ({
@@ -304,6 +324,13 @@ export class AgentRunnerController {
           completed: true,
         });
         break;
+      case 'stream_progress':
+        // Update accumulators without firing onChange — the working indicator
+        // pulls turnStats on its own spinner tick. Avoids a per-chunk emitChange
+        // storm that stutters input.
+        this.streamedCharsValue += event.charDelta;
+        this.streamModeValue = event.mode;
+        return;
       case 'done': {
         const done = event as DoneEvent;
         if (done.answer) {
@@ -318,6 +345,7 @@ export class AgentRunnerController {
           tokensPerSecond: done.tokensPerSecond,
         }));
         this.workingStateValue = { status: 'idle' };
+        this.resetTurnStats();
         break;
       }
     }

--- a/src/controllers/agent-runner.ts
+++ b/src/controllers/agent-runner.ts
@@ -1,4 +1,5 @@
 import { Agent } from '../agent/agent.js';
+import { AgentSdkAgent } from '../agent/agent-sdk-agent.js';
 import type { InMemoryChatHistory } from '../utils/in-memory-chat-history.js';
 import { defaultQueue } from '../utils/message-queue.js';
 import type {
@@ -11,6 +12,13 @@ import type { DisplayEvent } from '../agent/types.js';
 import type { HistoryItem, HistoryItemStatus, WorkingState } from '../types.js';
 
 type ChangeListener = () => void;
+
+/** Parse a truthy env flag ('1'/'true'/'yes'), tolerating undefined. */
+function isEnvFlagEnabled(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  const v = value.trim().toLowerCase();
+  return v !== '' && v !== '0' && v !== 'false' && v !== 'no';
+}
 
 export interface RunQueryResult {
   answer: string;
@@ -124,14 +132,7 @@ export class AgentRunnerController {
     this.emitChange();
 
     try {
-      const agent = await Agent.create({
-        ...this.agentConfig,
-        signal: this.abortController.signal,
-        requestToolApproval: this.requestToolApproval,
-        sessionApprovedTools: this.sessionApprovedTools,
-        messageQueue: defaultQueue,
-      });
-      const stream = agent.run(query, this.inMemoryChatHistory);
+      const stream = await this.createAgentStream(query);
       for await (const event of stream) {
         if (event.type === 'done') {
           finalAnswer = (event as DoneEvent).answer;
@@ -167,6 +168,58 @@ export class AgentRunnerController {
       this.abortController = null;
     }
   }
+
+  /**
+   * Build the event stream for a query, dispatching on provider:
+   * - `claude-agent-sdk` → AgentSdkAgent (loop delegated to the Agent SDK).
+   * - everything else     → the LangChain-based Agent.
+   * Both expose `run(query) → AsyncGenerator<AgentEvent>`, so the consumer loop
+   * is identical.
+   */
+  private async createAgentStream(query: string): Promise<AsyncGenerator<AgentEvent>> {
+    const signal = this.abortController?.signal;
+    if (this.agentConfig.modelProvider === 'claude-agent-sdk') {
+      const allowMetered = isEnvFlagEnabled(process.env.DEXTER_AGENT_SDK_ALLOW_METERED);
+      const budgetRaw = process.env.DEXTER_AGENT_SDK_MAX_BUDGET_USD;
+      const maxBudgetUsd = budgetRaw && Number.isFinite(Number(budgetRaw)) ? Number(budgetRaw) : undefined;
+      const agent = await AgentSdkAgent.create({
+        model: this.agentConfig.model ?? 'claude-fable-5',
+        signal,
+        channel: this.agentConfig.channel,
+        // The LangChain Agent's `maxIterations` (default 10) is a different budget
+        // than SDK agentic turns; let AgentSdkAgent use its own default (40) so
+        // multi-tool research is not cut short. Only forward an explicitly higher value.
+        maxTurns:
+          this.agentConfig.maxIterations && this.agentConfig.maxIterations > 10
+            ? this.agentConfig.maxIterations
+            : undefined,
+        maxBudgetUsd,
+        allowMetered,
+        requestUserInput: this.requestUserInput,
+      });
+      return agent.run(query);
+    }
+
+    const agent = await Agent.create({
+      ...this.agentConfig,
+      signal,
+      requestToolApproval: this.requestToolApproval,
+      sessionApprovedTools: this.sessionApprovedTools,
+      messageQueue: defaultQueue,
+    });
+    return agent.run(query, this.inMemoryChatHistory);
+  }
+
+  /**
+   * Bridge SDK-side user questions to the approval UI. The CLI's interaction
+   * surface is approval-oriented; treat an "allow" as an affirmative and a
+   * "deny" as a cancellation. Returns null when declined/cancelled so the SDK
+   * run does not hang.
+   */
+  private requestUserInput = async (prompt: string): Promise<string | null> => {
+    const decision = await this.requestToolApproval({ tool: 'ask_user', args: { question: prompt } });
+    return decision === 'deny' ? null : 'yes';
+  };
 
   private requestToolApproval = (request: { tool: string; args: Record<string, unknown> }) => {
     return new Promise<ApprovalDecision>((resolve) => {

--- a/src/controllers/agent-runner.ts
+++ b/src/controllers/agent-runner.ts
@@ -7,7 +7,8 @@ import type {
   ApprovalDecision,
   DoneEvent,
 } from '../agent/index.js';
-import type { DisplayEvent } from '../agent/types.js';
+import type { Question, UserAnswers } from '../tools/ask-user-question/types.js';
+import type { DisplayEvent, StreamMode } from '../agent/types.js';
 import type { HistoryItem, HistoryItemStatus, WorkingState } from '../types.js';
 
 type ChangeListener = () => void;
@@ -21,11 +22,16 @@ export class AgentRunnerController {
   private workingStateValue: WorkingState = { status: 'idle' };
   private errorValue: string | null = null;
   private pendingApprovalValue: { tool: string; args: Record<string, unknown> } | null = null;
+  private pendingQuestionValue: { questions: Question[] } | null = null;
+  private turnStartMsValue: number | null = null;
+  private streamedCharsValue = 0;
+  private streamModeValue: StreamMode | null = null;
   private agentConfig: AgentConfig;
   private readonly inMemoryChatHistory: InMemoryChatHistory;
   private readonly onChange?: ChangeListener;
   private abortController: AbortController | null = null;
   private approvalResolve: ((decision: ApprovalDecision) => void) | null = null;
+  private questionResolve: ((answers: UserAnswers) => void) | null = null;
   private sessionApprovedTools = new Set<string>();
 
   constructor(
@@ -52,6 +58,19 @@ export class AgentRunnerController {
 
   get pendingApproval(): { tool: string; args: Record<string, unknown> } | null {
     return this.pendingApprovalValue;
+  }
+
+  get pendingQuestion(): { questions: Question[] } | null {
+    return this.pendingQuestionValue;
+  }
+
+  get turnStats(): TurnStats | null {
+    if (this.turnStartMsValue === null) return null;
+    return {
+      turnStartMs: this.turnStartMsValue,
+      streamedChars: this.streamedCharsValue,
+      streamMode: this.streamModeValue ?? 'requesting',
+    };
   }
 
   get isProcessing(): boolean {
@@ -89,6 +108,17 @@ export class AgentRunnerController {
     this.emitChange();
   }
 
+  respondToQuestion(answers: UserAnswers) {
+    if (!this.questionResolve) {
+      return;
+    }
+    this.questionResolve(answers);
+    this.questionResolve = null;
+    this.pendingQuestionValue = null;
+    this.workingStateValue = { status: 'thinking' };
+    this.emitChange();
+  }
+
   cancelExecution() {
     if (this.abortController) {
       this.abortController.abort();
@@ -98,6 +128,11 @@ export class AgentRunnerController {
       this.approvalResolve('deny');
       this.approvalResolve = null;
       this.pendingApprovalValue = null;
+    }
+    if (this.questionResolve) {
+      this.questionResolve({ answers: [], declined: true });
+      this.questionResolve = null;
+      this.pendingQuestionValue = null;
     }
     this.markLastProcessing('interrupted');
     this.workingStateValue = { status: 'idle' };
@@ -128,6 +163,7 @@ export class AgentRunnerController {
         ...this.agentConfig,
         signal: this.abortController.signal,
         requestToolApproval: this.requestToolApproval,
+        requestUserInput: this.requestUserInput,
         sessionApprovedTools: this.sessionApprovedTools,
         messageQueue: defaultQueue,
       });
@@ -173,6 +209,15 @@ export class AgentRunnerController {
       this.approvalResolve = resolve;
       this.pendingApprovalValue = request;
       this.workingStateValue = { status: 'approval', toolName: request.tool };
+      this.emitChange();
+    });
+  };
+
+  private requestUserInput = (request: { questions: Question[] }) => {
+    return new Promise<UserAnswers>((resolve) => {
+      this.questionResolve = resolve;
+      this.pendingQuestionValue = request;
+      this.workingStateValue = { status: 'question' };
       this.emitChange();
     });
   };

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -81,6 +81,19 @@ export const PROVIDERS: ProviderDef[] = [
     modelPrefix: 'ollama:',
     contextWindow: 128_000,
   },
+  {
+    // Claude Agent SDK mode: the loop is delegated to @anthropic-ai/claude-agent-sdk,
+    // which resolves its own credentials (Claude Code login / OAuth / API key / etc.).
+    // No apiKeyEnvVar — like Ollama, this is a special (non-API-key) provider whose
+    // selection is by explicit provider id, not by model-name prefix. The models here
+    // share the 'claude-' name with the 'anthropic' provider, so this entry uses a
+    // non-matching prefix to avoid resolveProvider() routing collisions; dispatch keys
+    // off the stored provider id instead.
+    id: 'claude-agent-sdk',
+    displayName: 'Claude Agent SDK',
+    modelPrefix: 'claude-agent-sdk:',
+    contextWindow: 200_000,
+  },
 ];
 
 const defaultProvider = PROVIDERS.find((p) => p.id === 'openai')!;

--- a/src/tools/ask-user-question/ask-user-question.test.ts
+++ b/src/tools/ask-user-question/ask-user-question.test.ts
@@ -1,0 +1,168 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  AskUserQuestionSchema,
+  createAskUserQuestion,
+  formatAnswers,
+} from './ask-user-question.js';
+import type { Question, QuestionAnswer, UserAnswers } from './types.js';
+
+// ---------------------------------------------------------------------------
+// formatAnswers — the output contract handed back to the model
+// ---------------------------------------------------------------------------
+
+describe('formatAnswers', () => {
+  test('single-select renders header, question, and chosen label', () => {
+    const answers: QuestionAnswer[] = [
+      { header: 'Timeframe', question: 'Which horizon?', selected: ['Long-term'] },
+    ];
+    expect(formatAnswers(answers)).toBe('Q (Timeframe): Which horizon?\n  Answer: Long-term');
+  });
+
+  test('multi-select joins multiple labels with commas', () => {
+    const answers: QuestionAnswer[] = [
+      { header: 'Metrics', question: 'Which metrics?', selected: ['Revenue', 'Margins', 'FCF'] },
+    ];
+    expect(formatAnswers(answers)).toContain('Answer: Revenue, Margins, FCF');
+  });
+
+  test('Other text is appended after selected labels', () => {
+    const answers: QuestionAnswer[] = [
+      { header: 'Method', question: 'Which method?', selected: ['DCF'], otherText: 'Sum-of-parts' },
+    ];
+    expect(formatAnswers(answers)).toContain('Answer: DCF, Other: Sum-of-parts');
+  });
+
+  test('Other-only answer (no selected labels) still renders the Other text', () => {
+    const answers: QuestionAnswer[] = [
+      { header: 'Ticker', question: 'Which ticker?', selected: [], otherText: 'PLTR' },
+    ];
+    expect(formatAnswers(answers)).toContain('Answer: Other: PLTR');
+  });
+
+  test('notes are rendered on their own line', () => {
+    const answers: QuestionAnswer[] = [
+      { header: 'Detail', question: 'How deep?', selected: ['Brief'], notes: 'one paragraph max' },
+    ];
+    expect(formatAnswers(answers)).toBe(
+      'Q (Detail): How deep?\n  Answer: Brief\n  Notes: one paragraph max',
+    );
+  });
+
+  test('empty selection without other text reports no selection', () => {
+    const answers: QuestionAnswer[] = [
+      { header: 'X', question: 'Q?', selected: [] },
+    ];
+    expect(formatAnswers(answers)).toContain('Answer: (no selection)');
+  });
+
+  test('multiple questions are separated by a blank line', () => {
+    const answers: QuestionAnswer[] = [
+      { header: 'A', question: 'Q1?', selected: ['one'] },
+      { header: 'B', question: 'Q2?', selected: ['two'] },
+    ];
+    expect(formatAnswers(answers)).toBe(
+      'Q (A): Q1?\n  Answer: one\n\nQ (B): Q2?\n  Answer: two',
+    );
+  });
+
+  test('no answers reports an explicit empty message', () => {
+    expect(formatAnswers([])).toBe('The user submitted no answers.');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tool func — degradation and happy path via config.metadata.onUserInput
+// ---------------------------------------------------------------------------
+
+const SAMPLE_QUESTIONS: Question[] = [
+  {
+    question: 'Which valuation method?',
+    header: 'Method',
+    multiSelect: false,
+    options: [
+      { label: 'DCF', description: 'Discounted cash flow' },
+      { label: 'Comps', description: 'Trading comparables' },
+    ],
+  },
+];
+
+describe('createAskUserQuestion tool', () => {
+  test('returns the proceed-with-defaults message when no callback is provided', async () => {
+    const tool = createAskUserQuestion();
+    const result = await tool.invoke({ questions: SAMPLE_QUESTIONS });
+    expect(result).toContain('unavailable here');
+  });
+
+  test('returns the dismissed message when the user declines', async () => {
+    const tool = createAskUserQuestion();
+    const onUserInput = async (): Promise<UserAnswers> => ({ answers: [], declined: true });
+    const result = await tool.invoke({ questions: SAMPLE_QUESTIONS }, { metadata: { onUserInput } });
+    expect(result).toContain('dismissed the question prompt');
+  });
+
+  test('formats and returns the collected answers on success', async () => {
+    const tool = createAskUserQuestion();
+    const onUserInput = async (): Promise<UserAnswers> => ({
+      answers: [{ header: 'Method', question: 'Which valuation method?', selected: ['DCF'] }],
+    });
+    const result = await tool.invoke({ questions: SAMPLE_QUESTIONS }, { metadata: { onUserInput } });
+    expect(result).toBe('Q (Method): Which valuation method?\n  Answer: DCF');
+  });
+
+  test('passes the questions through to the callback', async () => {
+    const tool = createAskUserQuestion();
+    let received: Question[] | null = null;
+    const onUserInput = async (req: { questions: Question[] }): Promise<UserAnswers> => {
+      received = req.questions;
+      return { answers: [{ header: 'Method', question: 'Which valuation method?', selected: ['Comps'] }] };
+    };
+    await tool.invoke({ questions: SAMPLE_QUESTIONS }, { metadata: { onUserInput } });
+    expect(received).not.toBeNull();
+    expect(received![0].header).toBe('Method');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Schema validation
+// ---------------------------------------------------------------------------
+
+describe('AskUserQuestionSchema', () => {
+  const validQuestion = {
+    question: 'Q?',
+    header: 'H',
+    multiSelect: false,
+    options: [
+      { label: 'A', description: 'a' },
+      { label: 'B', description: 'b' },
+    ],
+  };
+
+  test('accepts a well-formed single question', () => {
+    expect(AskUserQuestionSchema.safeParse({ questions: [validQuestion] }).success).toBe(true);
+  });
+
+  test('rejects zero questions', () => {
+    expect(AskUserQuestionSchema.safeParse({ questions: [] }).success).toBe(false);
+  });
+
+  test('rejects more than four questions', () => {
+    const five = Array.from({ length: 5 }, () => validQuestion);
+    expect(AskUserQuestionSchema.safeParse({ questions: five }).success).toBe(false);
+  });
+
+  test('rejects a question with fewer than two options', () => {
+    const q = { ...validQuestion, options: [{ label: 'A', description: 'a' }] };
+    expect(AskUserQuestionSchema.safeParse({ questions: [q] }).success).toBe(false);
+  });
+
+  test('rejects a question with more than four options', () => {
+    const opts = Array.from({ length: 5 }, (_, i) => ({ label: `O${i}`, description: 'x' }));
+    const q = { ...validQuestion, options: opts };
+    expect(AskUserQuestionSchema.safeParse({ questions: [q] }).success).toBe(false);
+  });
+
+  test('rejects a header longer than 12 characters', () => {
+    const q = { ...validQuestion, header: 'ThisHeaderIsWayTooLong' };
+    expect(AskUserQuestionSchema.safeParse({ questions: [q] }).success).toBe(false);
+  });
+});

--- a/src/tools/ask-user-question/ask-user-question.ts
+++ b/src/tools/ask-user-question/ask-user-question.ts
@@ -1,0 +1,121 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import type { RunnableConfig } from '@langchain/core/runnables';
+import { z } from 'zod';
+import type { Question, QuestionAnswer, RequestUserInput, UserAnswers } from './types.js';
+
+/**
+ * Rich description for the ask_user_question tool.
+ * Used in the system prompt to guide the LLM on when and how to use this tool.
+ */
+export const ASK_USER_QUESTION_DESCRIPTION = `
+Ask the user one to four multiple-choice questions and pause until they answer.
+
+## When to Use
+
+- A request is genuinely ambiguous and the answer materially changes your approach
+  (e.g. which ticker/entity is meant, what timeframe, which valuation method, how much detail).
+- You hit a fork with a few discrete, well-defined options and need the user to choose.
+
+## When NOT to Use
+
+- When you can reasonably infer the answer or proceed under a stated assumption — prefer acting.
+- For open-ended information you could gather yourself with another tool (search, financials, filings).
+- More than once for the same decision. Do not re-ask after the user has answered or dismissed.
+
+## Schema
+
+- **questions** (required): 1-4 questions. Each has:
+  - **question**: the full question text.
+  - **header**: a short chip/tab label, max 12 characters (e.g. "Timeframe").
+  - **multiSelect**: true to let the user pick multiple options, false for a single choice.
+  - **options**: 2-4 options, each with a **label** and a **description**.
+
+## Usage Notes
+
+- An "Other" free-text choice is added to every question automatically — do NOT include your own.
+- The user may also attach free-text notes to any answer.
+- If you have a recommended option, put it FIRST and add "(Recommended)" to its label.
+- Make options mutually exclusive (unless multiSelect) and labels concise.
+
+## Returns
+
+For each question: the header, the selected option label(s), any "Other" free text, and any
+notes. Treat these as the user's decision and continue the task with them in mind.
+`.trim();
+
+const QuestionOptionSchema = z.object({
+  label: z.string().describe('Short selectable label. Put the recommended option first and mark it "(Recommended)".'),
+  description: z.string().describe('One-line explanation of what choosing this option means.'),
+});
+
+const QuestionSchema = z.object({
+  question: z.string().describe('The full question to ask the user.'),
+  header: z.string().max(12).describe('Short chip/tab label, max 12 chars (e.g. "Timeframe").'),
+  multiSelect: z.boolean().describe('Whether the user may select multiple options.'),
+  options: z.array(QuestionOptionSchema).min(2).max(4).describe('2-4 mutually exclusive options.'),
+});
+
+export const AskUserQuestionSchema = z.object({
+  questions: z.array(QuestionSchema).min(1).max(4).describe('1-4 questions to ask the user.'),
+});
+
+/** Message returned when no interactive user is available (gateway/subagent/headless). */
+const UNAVAILABLE_MESSAGE =
+  'The ask_user_question tool is unavailable here (no interactive user). Proceed using your ' +
+  'best judgment and reasonable default assumptions, and state the assumptions you made.';
+
+/** Message returned when the user dismisses the prompt without answering. */
+const DECLINED_MESSAGE =
+  'The user dismissed the question prompt without answering. Do not ask again; proceed with ' +
+  'reasonable defaults and note the assumptions you made.';
+
+/**
+ * Format the collected answers into the string handed back to the model.
+ * Pure function, exported for unit testing — this is the tool's output contract.
+ */
+export function formatAnswers(answers: QuestionAnswer[]): string {
+  if (answers.length === 0) {
+    return 'The user submitted no answers.';
+  }
+  return answers
+    .map((a) => {
+      const picks = [...a.selected];
+      if (a.otherText) {
+        picks.push(`Other: ${a.otherText}`);
+      }
+      const selected = picks.length ? picks.join(', ') : '(no selection)';
+      const notes = a.notes ? `\n  Notes: ${a.notes}` : '';
+      return `Q (${a.header}): ${a.question}\n  Answer: ${selected}${notes}`;
+    })
+    .join('\n\n');
+}
+
+/**
+ * Build the ask_user_question tool.
+ *
+ * The tool reads the `onUserInput` callback the CLI injects via `config.metadata`
+ * (the same channel `onProgress` uses), awaits the user's answers, and returns
+ * them formatted for the model. When the callback is absent it degrades gracefully
+ * so non-interactive surfaces never hang.
+ */
+export function createAskUserQuestion(): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'ask_user_question',
+    description: 'Ask the user 1-4 multiple-choice questions and wait for their answers. Returns the selected options.',
+    schema: AskUserQuestionSchema,
+    func: async (input, _runManager, config?: RunnableConfig) => {
+      const requestUserInput = config?.metadata?.onUserInput as RequestUserInput | undefined;
+
+      if (!requestUserInput) {
+        return UNAVAILABLE_MESSAGE;
+      }
+
+      const result: UserAnswers = await requestUserInput({ questions: input.questions as Question[] });
+
+      if (result.declined) {
+        return DECLINED_MESSAGE;
+      }
+      return formatAnswers(result.answers);
+    },
+  });
+}

--- a/src/tools/ask-user-question/types.ts
+++ b/src/tools/ask-user-question/types.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared types for the ask_user_question tool.
+ *
+ * These live in the tool directory (not src/agent) so the agent layer can import
+ * them type-only without creating a runtime agent → tool dependency cycle.
+ */
+
+/** A single selectable option within a question. */
+export interface QuestionOption {
+  /** Short label shown in the list and echoed back as the answer. */
+  label: string;
+  /** One-line explanation of what choosing this option means. */
+  description: string;
+}
+
+/** One question presented to the user. */
+export interface Question {
+  /** The full question text. */
+  question: string;
+  /** Short chip/tab label (<=12 chars), e.g. "Timeframe". */
+  header: string;
+  /** Whether the user may select more than one option. */
+  multiSelect: boolean;
+  /**
+   * The model-supplied options (2-4). The interactive "Other" free-text choice
+   * is appended by the UI at render time — it is never part of this array.
+   */
+  options: QuestionOption[];
+}
+
+/** The user's answer to a single question, positionally aligned to questions[]. */
+export interface QuestionAnswer {
+  /** Echo of the question's header chip. */
+  header: string;
+  /** Echo of the question text. */
+  question: string;
+  /** Chosen option label(s). One for single-select, one-or-more for multi-select. */
+  selected: string[];
+  /** Free text entered via the "Other" option, if chosen. */
+  otherText?: string;
+  /** Optional free-text notes the user attached to this answer. */
+  notes?: string;
+}
+
+/** The full result returned from the interactive prompt. */
+export interface UserAnswers {
+  answers: QuestionAnswer[];
+  /** True when the user dismissed the prompt without answering. */
+  declined?: boolean;
+}
+
+/**
+ * The callback the CLI provides to collect answers. Threaded from the controller
+ * through AgentConfig and into the tool via `config.metadata.onUserInput`.
+ */
+export type RequestUserInput = (request: { questions: Question[] }) => Promise<UserAnswers>;

--- a/src/tools/finance/raw-screener.ts
+++ b/src/tools/finance/raw-screener.ts
@@ -1,0 +1,52 @@
+/**
+ * Raw structured screener — the same EDINET DB `/screener` endpoint as
+ * `company_screener`, but the caller supplies structured conditions directly
+ * instead of a natural-language query that an internal LLM translates.
+ *
+ * Used by Claude Agent SDK mode, where the main model constructs the screening
+ * conditions itself (no internal LLM re-call inside the tool).
+ */
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { formatToolResult } from '../types.js';
+import { api } from './api.js';
+import {
+  AVAILABLE_METRICS,
+  ScreenerConditionSchema,
+  type ScreenerConditions,
+} from './screen-companies.js';
+
+export const RAW_SCREENER_DESCRIPTION = `
+Screen Japanese listed companies by explicit financial criteria. Supply structured conditions directly (metric key + operator + threshold in display units). AND logic across conditions.
+
+${AVAILABLE_METRICS}
+`.trim();
+
+export function createRawScreener(): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'screen_companies',
+    description: RAW_SCREENER_DESCRIPTION,
+    schema: ScreenerConditionSchema,
+    func: async (input: ScreenerConditions) => {
+      try {
+        const params: Record<string, string | number | undefined> = {
+          conditions: JSON.stringify(input.conditions),
+          limit: input.limit ?? 25,
+        };
+        if (input.industry) params.industry = input.industry;
+        if (input.sort_by) params.sort = input.sort_by;
+
+        const { data, url } = await api.get('/screener', params);
+        return formatToolResult(data, [url]);
+      } catch (error) {
+        return formatToolResult(
+          {
+            error: 'Screener request failed',
+            details: error instanceof Error ? error.message : String(error),
+            conditions: input.conditions,
+          },
+          [],
+        );
+      }
+    },
+  });
+}

--- a/src/tools/finance/screen-companies.ts
+++ b/src/tools/finance/screen-companies.ts
@@ -35,7 +35,7 @@ Screens for Japanese listed companies matching financial criteria. Takes a natur
 `.trim();
 
 // Available metrics for the EDINET DB screener
-const AVAILABLE_METRICS = `
+export const AVAILABLE_METRICS = `
 Supported metrics (use exact keys):
 - roe: Return on Equity (%)
 - roic: Return on Invested Capital (%)
@@ -71,7 +71,7 @@ Industries (Japanese, exact match):
 情報・通信業, 卸売業, 電気機器, 輸送用機器, 医薬品, 銀行業, 小売業, サービス業, 化学, 機械, 建設業, 不動産業, 食料品, 鉄鋼, 証券・商品先物取引業, 保険業, etc.
 `.trim();
 
-const ScreenerConditionSchema = z.object({
+export const ScreenerConditionSchema = z.object({
   conditions: z.array(z.object({
     metric: z.string().describe('Metric key from the available metrics list'),
     operator: z.enum(['gte', 'lte', 'gt', 'lt', 'eq']).describe('Comparison operator'),
@@ -82,7 +82,7 @@ const ScreenerConditionSchema = z.object({
   sort_by: z.string().optional().describe('Sort results by this metric key'),
 });
 
-type ScreenerConditions = z.infer<typeof ScreenerConditionSchema>;
+export type ScreenerConditions = z.infer<typeof ScreenerConditionSchema>;
 
 function buildScreenerPrompt(): string {
   return `You are a Japanese stock screening assistant.

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -18,6 +18,7 @@ import { cronTool, CRON_TOOL_DESCRIPTION } from './cron/cron-tool.js';
 import { memoryGetTool, MEMORY_GET_DESCRIPTION, memorySearchTool, MEMORY_SEARCH_DESCRIPTION, memoryUpdateTool, MEMORY_UPDATE_DESCRIPTION } from './memory/index.js';
 import { discoverSkills } from '../skills/index.js';
 import { createSpawnSubagent, SPAWN_SUBAGENT_DESCRIPTION } from './subagent/spawn-subagent.js';
+import { createAskUserQuestion, ASK_USER_QUESTION_DESCRIPTION } from './ask-user-question/ask-user-question.js';
 
 /**
  * A registered tool with its rich description for system prompt injection.
@@ -66,6 +67,13 @@ export function getToolRegistry(model: string): RegisteredTool[] {
       description: SCREEN_COMPANIES_DESCRIPTION,
       compactDescription: 'Screen Japanese listed companies by financial criteria (PER, ROE, growth, margins, etc.).',
       concurrencySafe: true,
+    },
+    {
+      name: 'ask_user_question',
+      tool: createAskUserQuestion(),
+      description: ASK_USER_QUESTION_DESCRIPTION,
+      compactDescription: 'Ask the user 1-4 multiple-choice questions mid-turn and wait for their answers. CLI only.',
+      concurrencySafe: false,
     },
     {
       name: 'web_fetch',

--- a/src/tools/search/index.ts
+++ b/src/tools/search/index.ts
@@ -31,3 +31,28 @@ export { exaSearch } from './exa.js';
 export { perplexitySearch } from './perplexity.js';
 export { langSearch } from './langsearch.js';
 export { xSearchTool, X_SEARCH_DESCRIPTION } from './x-search.js';
+export { createWebSearchTool, type WebSearchProvider } from './web-search.js';
+
+import type { StructuredToolInterface } from '@langchain/core/tools';
+import { createWebSearchTool as buildWebSearch, type WebSearchProvider } from './web-search.js';
+import { exaSearch as exaSearchTool } from './exa.js';
+import { perplexitySearch as perplexitySearchTool } from './perplexity.js';
+import { tavilySearch as tavilySearchTool } from './tavily.js';
+import { langSearch as langSearchTool } from './langsearch.js';
+
+/**
+ * Build a raw web_search tool for Claude Agent SDK mode from whichever provider
+ * keys are set. Returns null when no provider is configured. Unlike the registry
+ * version, this does not consult user settings for a preferred provider order —
+ * SDK mode keeps configuration minimal. The returned tool performs no internal
+ * LLM call; it aggregates raw provider results.
+ */
+export function buildWebSearchToolForSdk(): StructuredToolInterface | null {
+  const providers: WebSearchProvider[] = [];
+  if (process.env.EXASEARCH_API_KEY) providers.push({ id: 'exa', name: 'Exa', tool: exaSearchTool });
+  if (process.env.PERPLEXITY_API_KEY) providers.push({ id: 'perplexity', name: 'Perplexity', tool: perplexitySearchTool });
+  if (process.env.TAVILY_API_KEY) providers.push({ id: 'tavily', name: 'Tavily', tool: tavilySearchTool });
+  if (process.env.LANGSEARCH_API_KEY) providers.push({ id: 'langsearch', name: 'LangSearch', tool: langSearchTool });
+  if (providers.length === 0) return null;
+  return buildWebSearch(providers);
+}

--- a/src/tools/subagent/types.ts
+++ b/src/tools/subagent/types.ts
@@ -24,7 +24,7 @@ export interface SubagentTypeConfig {
  * Tools a subagent may never receive. The delegate tool is listed here so a
  * subagent can never spawn its own subagents — delegation is one level deep.
  */
-export const SUBAGENT_DISALLOWED_TOOLS = new Set<string>(['spawn_subagent']);
+export const SUBAGENT_DISALLOWED_TOOLS = new Set<string>(['spawn_subagent', 'ask_user_question']);
 
 /**
  * Read-only tools available to a general-purpose subagent. Deliberately excludes

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,8 @@ export type WorkingState =
   | { status: 'idle' }
   | { status: 'thinking' }
   | { status: 'tool'; toolName: string }
-  | { status: 'approval'; toolName: string };
+  | { status: 'approval'; toolName: string }
+  | { status: 'question' };
 
 export type HistoryItemStatus = 'processing' | 'complete' | 'error' | 'interrupted';
 

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -36,6 +36,14 @@ const PROVIDER_MODELS: Record<string, Model[]> = {
     { id: 'deepseek-v4-pro', displayName: 'DeepSeek V4 Pro' },
     { id: 'deepseek-v4-flash', displayName: 'DeepSeek V4 Flash' },
   ],
+  // Claude Agent SDK mode — models are passed straight through to the SDK's
+  // `model` option (verified honored). If the SDK reports model_not_found, the
+  // agent surfaces a fallback message listing these ids.
+  'claude-agent-sdk': [
+    { id: 'claude-fable-5', displayName: 'Fable 5' },
+    { id: 'claude-opus-4-8', displayName: 'Opus 4.8' },
+    { id: 'claude-sonnet-4-6', displayName: 'Sonnet 4.6' },
+  ],
 };
 
 export const PROVIDERS: Provider[] = PROVIDER_DEFS.map((provider) => ({


### PR DESCRIPTION
## 内容

### 本家 virattt/dexter v1.0.0 追従
- `ask_user_question` tool (エージェントからの対話的な質問 UI、CLI 専用)
- 前回 cherry-pick の不完全 merge を修理 (turn-stats 配線、型整合)

### JP 独自機能: Claude Agent SDK モード (provider: `claude-agent-sdk`)
- Claude Code と同じ認証で動作 (認証は Agent SDK が解決。CLAUDE_CODE_OAUTH_TOKEN / Claude Code ログイン / ANTHROPIC_API_KEY のいずれでも同一コードパス)
- SDK built-in tools を全遮断 (`tools: []` + disallowedTools + canUseTool deny)、Dexter 財務ツールのみ in-process MCP で提供
- env allowlist + 課金経路ガード (意図しない従量課金経路は起動前に停止、`DEXTER_AGENT_SDK_ALLOW_METERED=1` で opt-in)
- `settingSources: []` (ユーザーの .claude 設定を読まない)

## テスト
- typecheck クリーン / **104 tests pass** (新規 45: env-guard 分類 / SDKMessage 全 variant 変換 / tool schema 整合)
- 実機ゲート: Claude Code ログイン認証 (API キーなし)・claude-fable-5 で EDINET ツール呼び出し込みタスク完走、built-in 起動ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)